### PR TITLE
feat: add offline tasting note support

### DIFF
--- a/Sniff/App/DI/AppDependencyContainer.swift
+++ b/Sniff/App/DI/AppDependencyContainer.swift
@@ -15,6 +15,10 @@ final class AppDependencyContainer {
 
     lazy var authService: AuthServiceType = AuthService.shared
     lazy var firestoreService: FirestoreService = .shared
+    lazy var coreDataStack: CoreDataStack = .shared
+    @MainActor lazy var localTastingNoteRepository = LocalTastingNoteRepository(
+        coreDataStack: coreDataStack
+    )
 
     func makePerfumeCatalogRepository() -> PerfumeCatalogRepositoryType {
         PerfumeCatalogRepository()
@@ -62,6 +66,7 @@ final class AppDependencyContainer {
     ) -> TastingNoteViewModel {
         TastingNoteViewModel(
             firestoreService: firestoreService,
+            localRepository: localTastingNoteRepository,
             perfumeScope: perfumeScope
         )
     }
@@ -88,6 +93,7 @@ final class AppDependencyContainer {
         initialPerfume: Perfume? = nil
     ) -> TastingNoteFormViewModel {
         TastingNoteFormViewModel(
+            localRepository: localTastingNoteRepository,
             editingNote: editingNote,
             initialPerfume: initialPerfume
         )

--- a/Sniff/Data/Local/CoreDataStack.swift
+++ b/Sniff/Data/Local/CoreDataStack.swift
@@ -1,0 +1,43 @@
+//
+//  CoreDataStack.swift
+//  Sniff
+//
+//  Created by Codex on 2026.04.23.
+//
+
+import CoreData
+import Foundation
+
+final class CoreDataStack {
+    static let shared = CoreDataStack()
+
+    let container: NSPersistentContainer
+
+    var viewContext: NSManagedObjectContext {
+        container.viewContext
+    }
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "Sniff")
+
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+
+        container.persistentStoreDescriptions.first?.shouldMigrateStoreAutomatically = true
+        container.persistentStoreDescriptions.first?.shouldInferMappingModelAutomatically = true
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+        container.loadPersistentStores { _, error in
+            if let error {
+                assertionFailure("CoreData load failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func saveIfNeeded() throws {
+        guard viewContext.hasChanges else { return }
+        try viewContext.save()
+    }
+}

--- a/Sniff/Data/Local/LocalTastingNoteEntity.swift
+++ b/Sniff/Data/Local/LocalTastingNoteEntity.swift
@@ -1,0 +1,34 @@
+//
+//  LocalTastingNoteEntity.swift
+//  Sniff
+//
+//  Created by Codex on 2026.04.23.
+//
+
+import CoreData
+import Foundation
+
+@objc(LocalTastingNoteEntity)
+final class LocalTastingNoteEntity: NSManagedObject {
+    @NSManaged var id: String
+    @NSManaged var remoteID: String?
+    @NSManaged var perfumeName: String
+    @NSManaged var brandName: String
+    @NSManaged var mainAccordsJSON: String
+    @NSManaged var concentration: String?
+    @NSManaged var rating: Int16
+    @NSManaged var moodTagsJSON: String
+    @NSManaged var revisitDesire: String?
+    @NSManaged var memo: String
+    @NSManaged var perfumeImageURL: String?
+    @NSManaged var createdAt: Date
+    @NSManaged var updatedAt: Date
+    @NSManaged var syncStatus: String
+    @NSManaged var isDeletedPending: Bool
+}
+
+extension LocalTastingNoteEntity {
+    static func fetchRequest() -> NSFetchRequest<LocalTastingNoteEntity> {
+        NSFetchRequest<LocalTastingNoteEntity>(entityName: "LocalTastingNoteEntity")
+    }
+}

--- a/Sniff/Data/Local/LocalTastingNoteRepository.swift
+++ b/Sniff/Data/Local/LocalTastingNoteRepository.swift
@@ -1,0 +1,314 @@
+//
+//  LocalTastingNoteRepository.swift
+//  Sniff
+//
+//  Created by Codex on 2026.04.23.
+//
+
+import CoreData
+import FirebaseAuth
+import FirebaseFirestore
+import Foundation
+
+extension Notification.Name {
+    static let tastingNotesDidChange = Notification.Name("sniff.tastingNotesDidChange")
+}
+
+enum TastingNoteSyncStatus: String {
+    case pending
+    case synced
+    case failed
+    case pendingDelete
+}
+
+@MainActor
+final class LocalTastingNoteRepository {
+    private let coreDataStack: CoreDataStack
+    private let database: Firestore
+
+    private var context: NSManagedObjectContext {
+        coreDataStack.viewContext
+    }
+
+    private var collectionRef: CollectionReference? {
+        guard let uid = Auth.auth().currentUser?.uid else { return nil }
+        return database
+            .collection("users").document(uid)
+            .collection("tastingRecords")
+    }
+
+    init(
+        coreDataStack: CoreDataStack,
+        database: Firestore = .firestore()
+    ) {
+        self.coreDataStack = coreDataStack
+        self.database = database
+    }
+
+    func loadNotes() throws -> [TastingNote] {
+        let request = LocalTastingNoteEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "isDeletedPending == NO")
+        request.sortDescriptors = [
+            NSSortDescriptor(key: #keyPath(LocalTastingNoteEntity.createdAt), ascending: false)
+        ]
+
+        return try context.fetch(request).map(makeTastingNote)
+    }
+
+    @discardableResult
+    func save(_ note: TastingNote) async throws -> TastingNote {
+        let entity = try entityForSaving(note)
+        apply(note, to: entity)
+        entity.syncStatus = TastingNoteSyncStatus.pending.rawValue
+        entity.isDeletedPending = false
+        try coreDataStack.saveIfNeeded()
+        notifyChange()
+
+        await syncPendingChanges()
+        return makeTastingNote(entity)
+    }
+
+    func delete(_ note: TastingNote) async throws {
+        guard let id = note.id else { return }
+        guard let entity = try findEntity(id: id) else { return }
+
+        if entity.remoteID == nil {
+            context.delete(entity)
+            try coreDataStack.saveIfNeeded()
+            notifyChange()
+            return
+        }
+
+        entity.isDeletedPending = true
+        entity.syncStatus = TastingNoteSyncStatus.pendingDelete.rawValue
+        try coreDataStack.saveIfNeeded()
+        notifyChange()
+        await syncPendingChanges()
+    }
+
+    func delete(ids: Set<String>) async throws {
+        for id in ids {
+            guard let entity = try findEntity(id: id) else { continue }
+
+            if entity.remoteID == nil {
+                context.delete(entity)
+            } else {
+                entity.isDeletedPending = true
+                entity.syncStatus = TastingNoteSyncStatus.pendingDelete.rawValue
+            }
+        }
+
+        try coreDataStack.saveIfNeeded()
+        notifyChange()
+        await syncPendingChanges()
+    }
+
+    func refreshFromRemote() async {
+        guard let ref = collectionRef else { return }
+
+        do {
+            let snapshot = try await ref
+                .order(by: "createdAt", descending: true)
+                .getDocuments()
+
+            for document in snapshot.documents {
+                guard var note = try? document.data(as: TastingNote.self) else { continue }
+                note.id = document.documentID
+                let entity = try findEntity(remoteID: document.documentID)
+                    ?? findEntity(id: document.documentID)
+                    ?? LocalTastingNoteEntity(context: context)
+
+                if currentID(for: entity).isEmpty {
+                    entity.id = document.documentID
+                }
+
+                apply(note, to: entity)
+                entity.remoteID = document.documentID
+                entity.syncStatus = TastingNoteSyncStatus.synced.rawValue
+                entity.isDeletedPending = false
+            }
+
+            try coreDataStack.saveIfNeeded()
+            notifyChange()
+        } catch {
+            // 원격 동기화 실패 시 로컬 데이터는 그대로 사용한다.
+        }
+    }
+
+    func syncPendingChanges() async {
+        guard let ref = collectionRef else { return }
+
+        do {
+            let request = LocalTastingNoteEntity.fetchRequest()
+            request.predicate = NSPredicate(
+                format: "syncStatus IN %@",
+                [
+                    TastingNoteSyncStatus.pending.rawValue,
+                    TastingNoteSyncStatus.failed.rawValue,
+                    TastingNoteSyncStatus.pendingDelete.rawValue
+                ]
+            )
+
+            let entities = try context.fetch(request)
+
+            for entity in entities {
+                if entity.isDeletedPending || entity.syncStatus == TastingNoteSyncStatus.pendingDelete.rawValue {
+                    try await syncDelete(entity, ref: ref)
+                } else {
+                    try await syncUpsert(entity, ref: ref)
+                }
+            }
+
+            try coreDataStack.saveIfNeeded()
+            notifyChange()
+        } catch {
+            markPendingEntitiesAsFailed()
+            try? coreDataStack.saveIfNeeded()
+        }
+    }
+
+    // MARK: - Private
+
+    private func entityForSaving(_ note: TastingNote) throws -> LocalTastingNoteEntity {
+        if let id = note.id, let existing = try findEntity(id: id) {
+            return existing
+        }
+
+        if let remoteID = note.id, let existing = try findEntity(remoteID: remoteID) {
+            return existing
+        }
+
+        if let duplicate = try findLatestDuplicate(perfumeName: note.perfumeName, brandName: note.brandName) {
+            return duplicate
+        }
+
+        let entity = LocalTastingNoteEntity(context: context)
+        entity.id = note.id ?? UUID().uuidString
+        return entity
+    }
+
+    private func findEntity(id: String) throws -> LocalTastingNoteEntity? {
+        let request = LocalTastingNoteEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private func findEntity(remoteID: String) throws -> LocalTastingNoteEntity? {
+        let request = LocalTastingNoteEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "remoteID == %@", remoteID)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private func findLatestDuplicate(perfumeName: String, brandName: String) throws -> LocalTastingNoteEntity? {
+        let request = LocalTastingNoteEntity.fetchRequest()
+        request.predicate = NSPredicate(
+            format: "isDeletedPending == NO AND perfumeName ==[c] %@ AND brandName ==[c] %@",
+            perfumeName.trimmingCharacters(in: .whitespacesAndNewlines),
+            brandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        request.sortDescriptors = [
+            NSSortDescriptor(key: #keyPath(LocalTastingNoteEntity.createdAt), ascending: false)
+        ]
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private func syncUpsert(_ entity: LocalTastingNoteEntity, ref: CollectionReference) async throws {
+        let note = makeTastingNote(entity)
+        let documentRef: DocumentReference
+
+        if let remoteID = entity.remoteID, !remoteID.isEmpty {
+            documentRef = ref.document(remoteID)
+        } else {
+            documentRef = ref.document()
+            entity.remoteID = documentRef.documentID
+        }
+
+        var remoteNote = note
+        remoteNote.id = entity.remoteID
+        try documentRef.setData(from: remoteNote)
+        entity.syncStatus = TastingNoteSyncStatus.synced.rawValue
+    }
+
+    private func syncDelete(_ entity: LocalTastingNoteEntity, ref: CollectionReference) async throws {
+        if let remoteID = entity.remoteID, !remoteID.isEmpty {
+            try await ref.document(remoteID).delete()
+        }
+        context.delete(entity)
+    }
+
+    private func notifyChange() {
+        NotificationCenter.default.post(name: .tastingNotesDidChange, object: nil)
+    }
+
+    private func markPendingEntitiesAsFailed() {
+        let request = LocalTastingNoteEntity.fetchRequest()
+        request.predicate = NSPredicate(
+            format: "syncStatus IN %@",
+            [
+                TastingNoteSyncStatus.pending.rawValue,
+                TastingNoteSyncStatus.pendingDelete.rawValue
+            ]
+        )
+
+        guard let entities = try? context.fetch(request) else { return }
+        entities.forEach { $0.syncStatus = TastingNoteSyncStatus.failed.rawValue }
+    }
+
+    private func apply(_ note: TastingNote, to entity: LocalTastingNoteEntity) {
+        if currentID(for: entity).isEmpty {
+            entity.id = note.id ?? UUID().uuidString
+        }
+
+        entity.perfumeName = note.perfumeName
+        entity.brandName = note.brandName
+        entity.mainAccordsJSON = encodeStringArray(note.mainAccords)
+        entity.concentration = note.concentration
+        entity.rating = Int16(note.rating)
+        entity.moodTagsJSON = encodeStringArray(note.moodTags)
+        entity.revisitDesire = note.revisitDesire
+        entity.memo = note.memo
+        entity.perfumeImageURL = note.perfumeImageURL
+        entity.createdAt = note.createdAt
+        entity.updatedAt = note.updatedAt
+    }
+
+    private func makeTastingNote(_ entity: LocalTastingNoteEntity) -> TastingNote {
+        TastingNote(
+            id: entity.id,
+            perfumeName: entity.perfumeName,
+            brandName: entity.brandName,
+            mainAccords: decodeStringArray(entity.mainAccordsJSON),
+            concentration: entity.concentration,
+            rating: Int(entity.rating),
+            moodTags: decodeStringArray(entity.moodTagsJSON),
+            revisitDesire: entity.revisitDesire,
+            memo: entity.memo,
+            perfumeImageURL: entity.perfumeImageURL,
+            createdAt: entity.createdAt,
+            updatedAt: entity.updatedAt
+        )
+    }
+
+    private func encodeStringArray(_ values: [String]) -> String {
+        guard let data = try? JSONEncoder().encode(values),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
+
+    private func decodeStringArray(_ value: String) -> [String] {
+        guard let data = value.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return decoded
+    }
+
+    private func currentID(for entity: LocalTastingNoteEntity) -> String {
+        (entity.value(forKey: #keyPath(LocalTastingNoteEntity.id)) as? String) ?? ""
+    }
+}

--- a/Sniff/Data/Remote/Firebase/FirestoreService.swift
+++ b/Sniff/Data/Remote/Firebase/FirestoreService.swift
@@ -193,13 +193,16 @@ final class FirestoreService {
             .collection("likes")
             .document(perfume.id)
 
-        let data: [String: Any] = [
+        // nil 옵셔널은 Firestore에 null로 전송되면 보안 규칙의
+        // (!('imageUrl' in data) || data.imageUrl is string) 검증 실패 → PERMISSION_DENIED
+        var data: [String: Any] = [
             "name": perfume.name,
             "brand": perfume.brand,
-            "imageUrl": perfume.imageUrl as Any,
             "mainAccords": perfume.mainAccords,
             "likedAt": now
         ]
+
+        if let imageUrl = perfume.imageUrl { data["imageUrl"] = imageUrl }
 
         try await ref.setData(data, merge: true)
     }
@@ -223,18 +226,21 @@ final class FirestoreService {
             .collection("collection")
             .document(perfume.id)
 
+        // nil 옵셔널은 Firestore에 null로 전송되면 보안 규칙의
+        // (!('field' in data) || data.field is string) 검증 실패 → PERMISSION_DENIED
+        // 따라서 nil인 옵셔널 필드는 딕셔너리에 포함하지 않음
         var data: [String: Any] = [
             "name": perfume.name,
             "brand": perfume.brand,
-            "imageUrl": perfume.imageUrl as Any,
             "mainAccords": perfume.mainAccords,
             "accordStrengths": Self.accordStrengthsForStorage(from: perfume),
-            "concentration": perfume.concentration as Any,
-            "gender": perfume.gender as Any,
             "addedAt": now,
             "updatedAt": now
         ]
 
+        if let imageUrl = perfume.imageUrl { data["imageUrl"] = imageUrl }
+        if let concentration = perfume.concentration { data["concentration"] = concentration }
+        if let gender = perfume.gender { data["gender"] = gender }
         if let memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             data["memo"] = memo
         }

--- a/Sniff/Domain/Recommendation/ScentFamilyNormalizer.swift
+++ b/Sniff/Domain/Recommendation/ScentFamilyNormalizer.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum ScentFamilyNormalizer {
 
-    static func canonicalName(for value: String?) -> String? {
+    nonisolated static func canonicalName(for value: String?) -> String? {
         guard let value else { return nil }
 
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -54,7 +54,7 @@ enum ScentFamilyNormalizer {
         }
     }
 
-    static func canonicalNames(for values: [String]) -> [String] {
+    nonisolated static func canonicalNames(for values: [String]) -> [String] {
         var seen = Set<String>()
 
         return values

--- a/Sniff/Presentation/common/Tab/PerfumeDetail/ViewControllers/PerfumeDetailView.swift
+++ b/Sniff/Presentation/common/Tab/PerfumeDetail/ViewControllers/PerfumeDetailView.swift
@@ -508,18 +508,30 @@ final class PerfumeDetailViewController: UIViewController {
     private func toggleLike() {
         guard let perfume = currentPerfume else { return }
 
-        if likedPerfumeIDs.contains(perfume.id) {
+        let wasLiked = likedPerfumeIDs.contains(perfume.id)
+        updateLikeState(for: perfume.id, isLiked: !wasLiked)
+        likeButton.isEnabled = false
+
+        if wasLiked {
             collectionRepository.deleteLikedPerfume(id: perfume.id)
                 .observe(on: MainScheduler.instance)
                 .subscribe(onCompleted: { [weak self] in
-                    self?.updateLikeState(for: perfume.id, isLiked: false)
+                    self?.likeButton.isEnabled = true
+                }, onError: { [weak self] error in
+                    self?.likeButton.isEnabled = true
+                    self?.updateLikeState(for: perfume.id, isLiked: wasLiked)
+                    self?.showErrorAlert(message: error.localizedDescription)
                 })
                 .disposed(by: disposeBag)
         } else {
             collectionRepository.saveLikedPerfume(perfume)
                 .observe(on: MainScheduler.instance)
                 .subscribe(onCompleted: { [weak self] in
-                    self?.updateLikeState(for: perfume.id, isLiked: true)
+                    self?.likeButton.isEnabled = true
+                }, onError: { [weak self] error in
+                    self?.likeButton.isEnabled = true
+                    self?.updateLikeState(for: perfume.id, isLiked: wasLiked)
+                    self?.showErrorAlert(message: error.localizedDescription)
                 })
                 .disposed(by: disposeBag)
         }
@@ -537,18 +549,30 @@ final class PerfumeDetailViewController: UIViewController {
     private func toggleOwnedCollection() {
         guard let perfume = currentPerfume else { return }
 
-        if ownedPerfumeIDs.contains(perfume.id) {
+        let wasOwned = ownedPerfumeIDs.contains(perfume.id)
+        updateOwnedState(for: perfume.id, isOwned: !wasOwned)
+        addCollectionButton.isEnabled = false
+
+        if wasOwned {
             collectionRepository.deleteCollectedPerfume(id: perfume.id)
                 .observe(on: MainScheduler.instance)
                 .subscribe(onCompleted: { [weak self] in
-                    self?.updateOwnedState(for: perfume.id, isOwned: false)
+                    self?.addCollectionButton.isEnabled = true
+                }, onError: { [weak self] error in
+                    self?.addCollectionButton.isEnabled = true
+                    self?.updateOwnedState(for: perfume.id, isOwned: wasOwned)
+                    self?.showErrorAlert(message: error.localizedDescription)
                 })
                 .disposed(by: disposeBag)
         } else {
             collectionRepository.saveCollectedPerfume(perfume, memo: nil)
                 .observe(on: MainScheduler.instance)
                 .subscribe(onCompleted: { [weak self] in
-                    self?.updateOwnedState(for: perfume.id, isOwned: true)
+                    self?.addCollectionButton.isEnabled = true
+                }, onError: { [weak self] error in
+                    self?.addCollectionButton.isEnabled = true
+                    self?.updateOwnedState(for: perfume.id, isOwned: wasOwned)
+                    self?.showErrorAlert(message: error.localizedDescription)
                 })
                 .disposed(by: disposeBag)
         }

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 이정인 on 4/16/26.
 //
 
-// MARK: - 등록 로직 + Fragella 검색
+// MARK: - 등록 로직
 import Foundation
 import FirebaseAuth
 import FirebaseFirestore
@@ -14,17 +14,8 @@ import Combine
 @MainActor
 final class TastingNoteFormViewModel: ObservableObject {
 
-    // MARK: - Published (검색)
+    // MARK: - Published (향수 정보)
 
-    @Published var searchText: String = ""
-    @Published private(set) var searchResults: [FragellaFragrance] = []
-    @Published private(set) var isSearching: Bool = false
-    @Published var isSearchResultVisible: Bool = false
-    @Published var searchGuideMessage: String?
-
-    // MARK: - Published (자동 입력)
-
-    @Published var selectedFragrance: FragellaFragrance?
     @Published var perfumeName: String = ""
     @Published var brandName: String = ""
     @Published var mainAccords: [String] = []
@@ -49,25 +40,9 @@ final class TastingNoteFormViewModel: ObservableObject {
     var allMoodTags: [String] { kMoodTagList }
 
     private var editingNote: TastingNote?
+    private let localRepository: LocalTastingNoteRepository
     var isEditMode: Bool { editingNote != nil }
     var navigationTitle: String { isEditMode ? "시향기 수정" : "시향기 등록" }
-
-    var displayCardFragrance: FragellaFragrance? {
-        guard !perfumeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return nil
-        }
-        if let selectedFragrance { return selectedFragrance }
-        return FragellaFragrance(
-            id: "\(brandName)|\(perfumeName)",
-            name: perfumeName,
-            brand: brandName,
-            koreanName: nil,
-            koreanBrand: nil,
-            mainAccords: mainAccords,
-            concentration: concentration.isEmpty ? nil : concentration,
-            imageURL: editingNote?.perfumeImageURL
-        )
-    }
 
     var canSave: Bool {
         !perfumeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
@@ -79,11 +54,7 @@ final class TastingNoteFormViewModel: ObservableObject {
 
     // MARK: - Private
 
-    private var cancellables = Set<AnyCancellable>()
-    private var latestSearchQuery: String = ""
-    private var translationTask: Task<Void, Never>?
-    /// selectFragrance 직후 searchText 변경이 debounce 재검색을 유발하지 않도록 차단
-    private var suppressNextSearch: Bool = false
+    private var perfumeImageURL: String?
 
     private var uid: String? { Auth.auth().currentUser?.uid }
 
@@ -96,14 +67,18 @@ final class TastingNoteFormViewModel: ObservableObject {
 
     // MARK: - Init
 
-    init(editingNote: TastingNote? = nil, initialPerfume: Perfume? = nil) {
+    init(
+        localRepository: LocalTastingNoteRepository,
+        editingNote: TastingNote? = nil,
+        initialPerfume: Perfume? = nil
+    ) {
+        self.localRepository = localRepository
         self.editingNote = editingNote
         if let editingNote {
             loadEditingNote(editingNote)
         } else if let initialPerfume {
             preloadPerfume(initialPerfume)
         }
-        setupSearchDebounce()
     }
 
     // MARK: - Load
@@ -123,209 +98,15 @@ final class TastingNoteFormViewModel: ObservableObject {
         })
         revisitDesire = note.revisitDesire
         memo = note.memo
-        searchText = note.perfumeName
-        selectedFragrance = nil
+        perfumeImageURL = note.perfumeImageURL
     }
 
     private func preloadPerfume(_ perfume: Perfume) {
-        let fragrance = FragellaFragrance(
-            id: perfume.id,
-            name: perfume.name,
-            brand: perfume.brand,
-            koreanName: nil,
-            koreanBrand: PerfumeKoreanTranslator.koreanBrand(for: perfume.brand),
-            mainAccords: PerfumeKoreanTranslator.koreanAccords(for: perfume.mainAccords),
-            concentration: perfume.concentration,
-            imageURL: perfume.imageUrl
-        )
-
-        selectedFragrance = fragrance
-        perfumeName = fragrance.displayName
-        brandName = fragrance.displayBrand
-        mainAccords = fragrance.mainAccords
-        concentration = fragrance.concentration ?? ""
-        suppressNextSearch = true
-        searchText = fragrance.displayName
-        isSearchResultVisible = false
-        searchResults = []
-        searchGuideMessage = nil
-        latestSearchQuery = fragrance.displayName
-    }
-
-    // MARK: - 검색 디바운스
-    // 한국어: 최소 2자 / 영문: 최소 2자로 통일
-
-    private func setupSearchDebounce() {
-        $searchText
-            .debounce(for: .milliseconds(150), scheduler: RunLoop.main)
-            .removeDuplicates()
-            .sink { [weak self] query in
-                guard let self else { return }
-
-                // 향수 선택 후 searchText를 프로그래밍으로 바꾼 경우 → 재검색 차단
-                if self.suppressNextSearch {
-                    self.suppressNextSearch = false
-                    return
-                }
-
-                let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                if trimmed.isEmpty {
-                    self.searchResults = []
-                    self.isSearchResultVisible = false
-                    self.isSearching = false
-                    self.searchGuideMessage = nil
-                    self.latestSearchQuery = ""
-                    return
-                }
-
-                if trimmed.count < 2 {
-                    self.searchResults = []
-                    self.isSearchResultVisible = false
-                    self.isSearching = false
-                    self.searchGuideMessage = "2자 이상 입력해주세요"
-                    self.latestSearchQuery = ""
-                    return
-                }
-
-                self.searchGuideMessage = nil
-                Task { await self.performSearch(query: trimmed) }
-            }
-            .store(in: &cancellables)
-    }
-
-    func searchButtonTapped() {
-        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            searchResults = []
-            isSearchResultVisible = false
-            searchGuideMessage = nil
-            return
-        }
-        guard trimmed.count >= 2 else {
-            searchResults = []
-            isSearchResultVisible = false
-            searchGuideMessage = "2자 이상 입력해주세요"
-            return
-        }
-        searchGuideMessage = nil
-        Task { await performSearch(query: trimmed) }
-    }
-
-    func performSearch(query: String) async {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 2 else {
-            searchResults = []
-            isSearchResultVisible = false
-            isSearching = false
-            searchGuideMessage = "2자 이상 입력해주세요"
-            return
-        }
-
-        latestSearchQuery = trimmed
-        let requestQuery = trimmed
-
-        isSearching = true
-        isSearchResultVisible = true
-        searchGuideMessage = nil
-
-        do {
-            // 1차 시도: 입력 쿼리 그대로 검색
-            var results = try await TastingNoteFragellaAPI.search(query: requestQuery)
-
-            // 2차 시도: 한국어 포함 + 결과 없는 경우 → 영문으로 변환 후 재검색
-            if results.isEmpty && PerfumeKoreanTranslator.containsKorean(requestQuery) {
-                if let englishQuery = PerfumeKoreanTranslator.toEnglishQuery(requestQuery) {
-                    results = try await TastingNoteFragellaAPI.search(query: englishQuery)
-                }
-            }
-
-            guard latestSearchQuery == requestQuery else { return }
-
-            // 향수명 음역 번역 (결과 표시 전 완료 → 처음부터 한국어로 표시)
-            translationTask?.cancel()
-            let needsTranslation = results.filter { $0.koreanName == nil }
-            if !needsTranslation.isEmpty {
-                let englishNames = needsTranslation.map { $0.name }
-                if let translations = try? await PerfumeNameTranslationService.translate(names: englishNames),
-                   latestSearchQuery == requestQuery {
-                    results = results.map { fragrance in
-                        guard let korean = translations[fragrance.name] else { return fragrance }
-                        return FragellaFragrance(
-                            id: fragrance.id,
-                            name: fragrance.name,
-                            brand: fragrance.brand,
-                            koreanName: korean,
-                            koreanBrand: fragrance.koreanBrand,
-                            mainAccords: fragrance.mainAccords,
-                            concentration: fragrance.concentration,
-                            imageURL: fragrance.imageURL
-                        )
-                    }
-                }
-            }
-
-            guard latestSearchQuery == requestQuery else { return }
-            // 1차: 즉시 표시 (빠른 UX)
-            searchResults = results
-            isSearching = false
-
-            // 2차: 백그라운드에서 이미지 실존 검증 후 결과 정제
-            let verifyQuery = requestQuery
-            let verifyResults = results
-            Task {
-                let verified = await TastingNoteFragellaAPI.verifyImages(verifyResults)
-                if self.latestSearchQuery == verifyQuery {
-                    self.searchResults = verified
-                }
-            }
-        } catch {
-            guard latestSearchQuery == requestQuery else { return }
-            searchResults = []
-            isSearching = false
-            isSearchResultVisible = false
-            // 404 = 결과 없음 (에러 메시지 숨김)
-            if let apiErr = error as? FragellaAPIError,
-               case .noResults = apiErr {
-                searchGuideMessage = nil
-            } else {
-                searchGuideMessage = error.localizedDescription
-            }
-        }
-    }
-
-    // MARK: - 향수 선택
-
-    func selectFragrance(_ fragrance: FragellaFragrance) {
-        selectedFragrance = fragrance
-        // displayName(한국어 우선), displayBrand(한국어 우선) 저장
-        perfumeName = fragrance.displayName
-        brandName = fragrance.displayBrand
-        // mainAccords는 이미 parseFragrances에서 한국어 변환됨
-        mainAccords = fragrance.mainAccords
-        concentration = fragrance.concentration ?? ""
-
-        suppressNextSearch = true
-        searchText = fragrance.displayName
-        isSearchResultVisible = false
-        searchResults = []
-        searchGuideMessage = nil
-        latestSearchQuery = fragrance.displayName
-    }
-
-    func clearSelectedFragrance() {
-        let autoInsertedTags = Set(mainAccords.filter { allMoodTags.contains($0) })
-        selectedFragrance = nil
-        perfumeName = ""
-        brandName = ""
-        mainAccords = []
-        concentration = ""
-        searchText = ""
-        isSearchResultVisible = false
-        searchResults = []
-        searchGuideMessage = nil
-        latestSearchQuery = ""
-        selectedMoodTags.subtract(autoInsertedTags)
+        perfumeName = PerfumePresentationSupport.displayPerfumeName(perfume.name)
+        brandName = PerfumePresentationSupport.displayBrand(perfume.brand)
+        mainAccords = PerfumeKoreanTranslator.koreanAccords(for: perfume.mainAccords)
+        concentration = perfume.concentration ?? ""
+        perfumeImageURL = perfume.imageUrl
     }
 
     // MARK: - 태그 토글
@@ -348,20 +129,15 @@ final class TastingNoteFormViewModel: ObservableObject {
     func reset() {
         errorMessage = nil
         saveSuccess = false
-        searchResults = []
-        isSearchResultVisible = false
-        selectedFragrance = nil
-        searchGuideMessage = nil
-        latestSearchQuery = ""
 
         if let editingNote {
             loadEditingNote(editingNote)
         } else {
-            searchText = ""
             perfumeName = ""
             brandName = ""
             mainAccords = []
             concentration = ""
+            perfumeImageURL = nil
             rating = 0
             selectedMoodTags = []
             revisitDesire = nil
@@ -372,7 +148,8 @@ final class TastingNoteFormViewModel: ObservableObject {
     // MARK: - 저장
 
     func save() async {
-        guard canSave, let ref = collectionRef else { return }
+        guard !isSaving else { return }
+        guard canSave else { return }
         isSaving = true
         errorMessage = nil
 
@@ -387,18 +164,14 @@ final class TastingNoteFormViewModel: ObservableObject {
             moodTags: orderedMoodTags(from: selectedMoodTags),
             revisitDesire: revisitDesire,
             memo: memo.trimmingCharacters(in: .whitespacesAndNewlines),
-            perfumeImageURL: selectedFragrance?.imageURL ?? editingNote?.perfumeImageURL,
+            perfumeImageURL: perfumeImageURL,
             createdAt: editingNote?.createdAt ?? now,
             updatedAt: now
         )
 
         do {
-            if let id = editingNote?.id {
-                try ref.document(id).setData(from: note)
-            } else {
-                try ref.addDocument(from: note)
-            }
-            savedPerfumeName = perfumeName
+            let savedNote = try await localRepository.save(note)
+            savedPerfumeName = savedNote.perfumeName
             saveSuccess = true
         } catch {
             errorMessage = "저장 중 오류가 발생했어요"
@@ -413,201 +186,39 @@ final class TastingNoteFormViewModel: ObservableObject {
             return li < ri
         }
     }
-}
 
-// MARK: - Fragella API (한국어 번역 포함)
+    private func findDuplicateNote(in ref: CollectionReference) async throws -> TastingNoteDocument? {
+        let snapshot = try await ref.getDocuments()
+        let currentKey = duplicateKey(perfumeName: perfumeName, brandName: brandName)
 
-private enum TastingNoteFragellaAPI {
-
-    static func search(query: String) async throws -> [FragellaFragrance] {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 2 else { throw FragellaAPIError.minimumSearchLength }
-        let apiKey: String
-        do {
-            apiKey = try AppSecrets.fragellaAPIKey()
-        } catch {
-            throw FragellaAPIError.missingAPIKey
-        }
-
-        var components = URLComponents(string: "https://api.fragella.com/api/v1/fragrances")
-        components?.queryItems = [
-            URLQueryItem(name: "search", value: trimmed),
-            URLQueryItem(name: "limit", value: "20")
-        ]
-
-        guard let url = components?.url else { throw FragellaAPIError.invalidURL }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.timeoutInterval = 15
-        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let http = response as? HTTPURLResponse else { throw FragellaAPIError.invalidResponse }
-
-        // 404 = 결과 없음 (Fragella API 동작), 에러로 처리하지 않음
-        if http.statusCode == 404 {
-            return []
-        }
-
-        guard 200..<300 ~= http.statusCode else {
-            let msg = String(data: data, encoding: .utf8) ?? "알 수 없는 오류"
-            if http.statusCode == 400 && msg.localizedCaseInsensitiveContains("at least") {
-                throw FragellaAPIError.minimumSearchLength
+        let matches: [TastingNoteDocument] = snapshot.documents.compactMap { document -> TastingNoteDocument? in
+            guard var note = try? document.data(as: TastingNote.self),
+                  duplicateKey(perfumeName: note.perfumeName, brandName: note.brandName) == currentKey else {
+                return nil
             }
-            throw FragellaAPIError.serverError(statusCode: http.statusCode, message: msg)
+            note.id = document.documentID
+            return TastingNoteDocument(id: document.documentID, note: note)
         }
 
-        // Primary 이미지 URL이 있는 결과만 포함 (이미지 실존 검증은 백그라운드에서 수행)
-        return try parseFragrances(from: data).filter { $0.imageURL != nil }
+        return matches
+            .sorted { lhs, rhs in lhs.note.createdAt > rhs.note.createdAt }
+            .first
     }
 
-    // MARK: - 파싱 (accord 한국어 변환 포함)
-
-    private static func parseFragrances(from data: Data) throws -> [FragellaFragrance] {
-        let jsonObject = try JSONSerialization.jsonObject(with: data)
-
-        let items: [[String: Any]]
-        if let array = jsonObject as? [[String: Any]] {
-            items = array
-        } else if let dict = jsonObject as? [String: Any] {
-            items = (dict["data"] ?? dict["results"] ?? dict["items"] ?? dict["fragrances"])
-                .flatMap { $0 as? [[String: Any]] } ?? []
-        } else {
-            throw FragellaAPIError.decodingFailed
-        }
-
-        return items.compactMap { item in
-            // 영문명 (필수)
-            guard let name  = strValue(["Name", "name"], item)?.nilIfBlank,
-                  let brand = strValue(["Brand", "brand"], item)?.nilIfBlank else { return nil }
-
-            // 한국어 이름 (API 제공 시)
-            let koreanName  = strValue(["koreanName", "korean_name", "nameKo", "name_ko",
-                                        "KoreanName", "Korean Name"], item)?.nilIfBlank
-            let koreanBrand = strValue(["koreanBrand", "korean_brand", "brandKo", "brand_ko",
-                                        "KoreanBrand", "Korean Brand"], item)?.nilIfBlank
-
-            let fragranceID = strValue(["id", "ID", "fragranceId", "fragranceID", "Fragrance ID"], item)?.nilIfBlank
-                ?? "\(brand)|\(name)"
-
-            // 영문 accord → 한국어 변환
-            let rawAccords  = arrValue(["Main Accords", "mainAccords", "main_accords"], item)
-            let mainAccords = PerfumeKoreanTranslator.koreanAccords(for: rawAccords)
-
-            let concentration = strValue(["OilType", "oilType", "concentration"], item)?.nilIfBlank
-
-            // 이미지 URL — primary 이미지만 사용 (fallback은 실제 이미지 없는 경우가 많아 제외)
-            let imageURL = strValue(["Image URL", "imageURL", "imageUrl", "image_url"], item)?.nilIfBlank
-
-            return FragellaFragrance(
-                id: fragranceID,
-                name: name,
-                brand: brand,
-                koreanName: koreanName,
-                koreanBrand: koreanBrand,
-                mainAccords: mainAccords,
-                concentration: concentration,
-                imageURL: imageURL
-            )
-        }
-    }
-
-    // MARK: - 이미지 실존 검증 (동시 HEAD 요청, 4초 타임아웃)
-
-    static func verifyImages(_ fragrances: [FragellaFragrance]) async -> [FragellaFragrance] {
-        guard !fragrances.isEmpty else { return fragrances }
-
-        typealias IndexedResult = (index: Int, valid: Bool)
-
-        let results: [IndexedResult] = await withTaskGroup(of: IndexedResult.self) { group in
-            for (i, fragrance) in fragrances.enumerated() {
-                guard let urlString = fragrance.imageURL,
-                      let url = URL(string: urlString) else {
-                    continue
-                }
-                group.addTask {
-                    var req = URLRequest(url: url)
-                    req.httpMethod = "HEAD"
-                    req.timeoutInterval = 2.5
-                    // 일부 CDN은 HEAD 미지원 → Range 헤더로 최소 바이트만 요청
-                    req.setValue("bytes=0-0", forHTTPHeaderField: "Range")
-
-                    guard let (_, resp) = try? await URLSession.shared.data(for: req),
-                          let http = resp as? HTTPURLResponse else {
-                        return (i, true)  // 네트워크 오류는 일단 유효로 처리
-                    }
-                    // 2xx / 3xx / 206 → 유효, 404/410 등 4xx·5xx → 무효
-                    return (i, http.statusCode < 400)
-                }
-            }
-            var collected: [IndexedResult] = []
-            for await r in group { collected.append(r) }
-            return collected
-        }
-
-        let validIndices = Set(results.filter { $0.valid }.map { $0.index })
-        return fragrances.enumerated()
-            .filter { validIndices.contains($0.offset) }
-            .map { $0.element }
-    }
-
-    // MARK: - 파싱 헬퍼
-
-    private static func strValue(_ keys: [String], _ dict: [String: Any]) -> String? {
-        for key in keys {
-            if let v = dict[key] as? String { return v }
-            if let v = dict[key] as? NSNumber { return v.stringValue }
-        }
-        return nil
-    }
-
-    private static func arrValue(_ keys: [String], _ dict: [String: Any]) -> [String] {
-        for key in keys {
-            if let arr = dict[key] as? [String] { return arr }
-            if let arr = dict[key] as? [Any] {
-                return arr.compactMap {
-                    ($0 as? String) ?? ($0 as? NSNumber)?.stringValue
-                }
-            }
-            if let str = dict[key] as? String {
-                let parts = str.split(separator: ",")
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                    .filter { !$0.isEmpty }
-                if !parts.isEmpty { return parts }
-            }
-        }
-        return []
+    private func duplicateKey(perfumeName: String, brandName: String) -> String {
+        let normalizedName = perfumeName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedBrand = brandName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return "\(normalizedBrand)|\(normalizedName)"
     }
 }
 
-// MARK: - Fragella Error
+private struct TastingNoteDocument {
+    let id: String
+    let note: TastingNote
 
-private enum FragellaAPIError: LocalizedError {
-    case missingAPIKey, minimumSearchLength, invalidURL
-    case invalidResponse, decodingFailed, noResults
-    case serverError(statusCode: Int, message: String)
-
-    var errorDescription: String? {
-        switch self {
-        case .missingAPIKey:         return "Fragella API 키를 먼저 설정해주세요"
-        case .minimumSearchLength:   return "2자 이상 입력해주세요"
-        case .invalidURL:            return "요청 URL 생성에 실패했어요"
-        case .invalidResponse:       return "응답을 확인할 수 없어요"
-        case .decodingFailed:        return "응답 해석에 실패했어요"
-        case .noResults:             return nil
-        case let .serverError(code, msg): return "검색 실패 (\(code))\n\(msg)"
-        }
-    }
-}
-
-// MARK: - Helpers
-
-private extension String {
-    var nilIfBlank: String? {
-        let t = trimmingCharacters(in: .whitespacesAndNewlines)
-        return t.isEmpty ? nil : t
-    }
+    var createdAt: Date { note.createdAt }
 }

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteViewModel.swift
@@ -8,7 +8,6 @@
 // MARK: - 목록 로직 + Firestore 연동
 import Foundation
 import FirebaseAuth
-import FirebaseFirestore
 import Combine
 
 // MARK: - 시향 기록 필터 타입
@@ -44,6 +43,7 @@ final class TastingNoteViewModel: ObservableObject {
     @Published var isDeleteMode: Bool = false
     @Published var showFormSheet: Bool = false
     @Published var toastMessage: String?
+    @Published private(set) var selectedNoteIDs: Set<String> = []
 
     /// 현재 선택된 필터
     @Published private(set) var selectedFilter: TastingNoteFilter = .all
@@ -60,17 +60,24 @@ final class TastingNoteViewModel: ObservableObject {
     var filteredNotes: [TastingNote] {
         let scopedNotes = notes.filter { note in
             guard let perfumeScope else { return true }
-            return noteKey(note) == perfumeKey(perfumeName: perfumeScope.perfumeName, brandName: perfumeScope.brandName)
+            return !noteKeys(note).isDisjoint(with: perfumeKeys(
+                perfumeName: perfumeScope.perfumeName,
+                brandName: perfumeScope.brandName
+            ))
         }
+
+        let filtered: [TastingNote]
 
         switch selectedFilter {
         case .all:
-            return scopedNotes
+            filtered = scopedNotes
         case .owned:
-            return scopedNotes.filter { ownedKeys.contains(noteKey($0)) }
+            filtered = scopedNotes.filter { !noteKeys($0).isDisjoint(with: ownedKeys) }
         case .liked:
-            return scopedNotes.filter { likedKeys.contains(noteKey($0)) }
+            filtered = scopedNotes.filter { !noteKeys($0).isDisjoint(with: likedKeys) }
         }
+
+        return uniqueLatestNotes(from: filtered)
     }
 
     /// 전체 목록이 비어있는지 (삭제 버튼 활성화 기준)
@@ -79,70 +86,60 @@ final class TastingNoteViewModel: ObservableObject {
     /// 필터 적용 후 결과가 없는지 (빈 상태 뷰 표시 기준)
     var isFilteredEmpty: Bool { filteredNotes.isEmpty }
 
+    var hasSelectedNotes: Bool { !selectedNoteIDs.isEmpty }
+
     private var uid: String? { Auth.auth().currentUser?.uid }
- 
-    private var collectionRef: CollectionReference? {
-        guard let uid else { return nil }
-        return Firestore.firestore()
-            .collection("users").document(uid)
-            .collection("tastingRecords")
-    }
  
     // MARK: - Private
  
-    private var listenerRegistration: ListenerRegistration?
     private var toastTask: Task<Void, Never>?
     private let firestoreService: FirestoreService
+    private let localRepository: LocalTastingNoteRepository
+    private let collectionCacheStore = CollectedPerfumeCacheStore()
  
     // MARK: - Init / Deinit
  
     init(
         firestoreService: FirestoreService,
+        localRepository: LocalTastingNoteRepository,
         perfumeScope: TastingNotePerfumeScope? = nil
     ) {
         self.firestoreService = firestoreService
+        self.localRepository = localRepository
         self.perfumeScope = perfumeScope
         fetchNotes()
         Task { await loadFilterKeys() }
     }
  
     deinit {
-        listenerRegistration?.remove()
         toastTask?.cancel()
     }
  
     // MARK: - 목록 실시간 조회
 
     func fetchNotes() {
-        guard let ref = collectionRef else { return }
-        isLoading = true
-
-        listenerRegistration = ref
-            .order(by: "createdAt", descending: true)
-            .addSnapshotListener { [weak self] snapshot, error in
-                guard let self else { return }
-                self.isLoading = false
-                if error != nil {
-                    // 권한 오류 등 리스너 에러는 조용히 무시하고 단발성 조회로 대체
-                    Task { await self.reload() }
-                    return
-                }
-                let decoded = snapshot?.documents.compactMap {
-                    try? $0.data(as: TastingNote.self)
-                } ?? []
-                self.notes = decoded
-            }
+        Task { await reload() }
     }
 
     // MARK: - 단발성 새로고침 (폼 닫힐 때, 리스너 실패 시 fallback)
 
     func reload() async {
-        guard let ref = collectionRef else { return }
+        isLoading = true
         do {
-            let snapshot = try await ref
-                .order(by: "createdAt", descending: true)
-                .getDocuments()
-            notes = snapshot.documents.compactMap { try? $0.data(as: TastingNote.self) }
+            notes = try localRepository.loadNotes()
+            await localRepository.syncPendingChanges()
+            await localRepository.refreshFromRemote()
+            notes = try localRepository.loadNotes()
+            await loadFilterKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func reloadFromLocal() async {
+        do {
+            notes = try localRepository.loadNotes()
             await loadFilterKeys()
         } catch {
             errorMessage = error.localizedDescription
@@ -155,12 +152,23 @@ final class TastingNoteViewModel: ObservableObject {
         noteToDelete = note
         showDeleteAlert = true
     }
+
+    func requestDeleteSelected() {
+        guard hasSelectedNotes else { return }
+        noteToDelete = nil
+        showDeleteAlert = true
+    }
  
     func confirmDelete() async {
-        guard let note = noteToDelete, let id = note.id,
-              let ref = collectionRef else { return }
+        if noteToDelete == nil {
+            await deleteSelectedNotes()
+            return
+        }
+
+        guard let note = noteToDelete else { return }
         do {
-            try await ref.document(id).delete()
+            try await localRepository.delete(note)
+            notes = try localRepository.loadNotes()
             noteToDelete = nil
             isDeleteMode = false
         } catch {
@@ -171,9 +179,9 @@ final class TastingNoteViewModel: ObservableObject {
     // MARK: - 삭제 (상세 화면에서 직접)
  
     func deleteNote(_ note: TastingNote) async {
-        guard let id = note.id, let ref = collectionRef else { return }
         do {
-            try await ref.document(id).delete()
+            try await localRepository.delete(note)
+            notes = try localRepository.loadNotes()
         } catch {
             errorMessage = "삭제 중 오류가 발생했어요"
         }
@@ -181,7 +189,27 @@ final class TastingNoteViewModel: ObservableObject {
  
     // MARK: - 삭제 모드 토글
  
-    func toggleDeleteMode() { isDeleteMode.toggle() }
+    func toggleDeleteMode() {
+        isDeleteMode.toggle()
+        if !isDeleteMode {
+            selectedNoteIDs.removeAll()
+            noteToDelete = nil
+        }
+    }
+
+    func toggleNoteSelection(_ note: TastingNote) {
+        guard let id = note.id else { return }
+        if selectedNoteIDs.contains(id) {
+            selectedNoteIDs.remove(id)
+        } else {
+            selectedNoteIDs.insert(id)
+        }
+    }
+
+    func isSelected(_ note: TastingNote) -> Bool {
+        guard let id = note.id else { return false }
+        return selectedNoteIDs.contains(id)
+    }
  
     // MARK: - 저장 완료 토스트
  
@@ -197,6 +225,20 @@ final class TastingNoteViewModel: ObservableObject {
  
     func clearError() { errorMessage = nil }
 
+    private func deleteSelectedNotes() async {
+        guard !selectedNoteIDs.isEmpty else { return }
+
+        do {
+            try await localRepository.delete(ids: selectedNoteIDs)
+            notes = try localRepository.loadNotes()
+            selectedNoteIDs.removeAll()
+            isDeleteMode = false
+            showDeleteAlert = false
+        } catch {
+            errorMessage = "삭제 중 오류가 발생했어요"
+        }
+    }
+
     // MARK: - 필터 선택 / 해제
 
     /// 선택한 필터로 전환한다.
@@ -208,26 +250,56 @@ final class TastingNoteViewModel: ObservableObject {
     // MARK: - 필터 키 로딩 (보유/LIKE 향수 → 브랜드|이름 소문자 Set)
 
     private func loadFilterKeys() async {
+        let cachedOwned = collectionCacheStore.load()
         do {
             async let ownedFetch = firestoreService.fetchCollection()
             async let likedFetch = firestoreService.fetchLikedPerfumes()
             let (owned, liked) = try await (ownedFetch, likedFetch)
-            ownedKeys = Set(owned.map { perfumeKey(perfumeName: $0.name, brandName: $0.brand) })
-            likedKeys = Set(liked.map { perfumeKey(perfumeName: $0.name, brandName: $0.brand) })
+            let mergedOwned = mergeCollection(remote: owned, cached: cachedOwned)
+            ownedKeys = Set(mergedOwned.flatMap { perfumeKeys(perfumeName: $0.name, brandName: $0.brand) })
+            likedKeys = Set(liked.flatMap { perfumeKeys(perfumeName: $0.name, brandName: $0.brand) })
         } catch {
-            // 로딩 실패 시 빈 Set 유지 (필터 결과 없음으로 표시)
-            ownedKeys = []
+            // 보유 향수는 상세 화면에서 등록 직후 UserDefaults 캐시에 먼저 반영될 수 있다.
+            ownedKeys = Set(cachedOwned.flatMap { perfumeKeys(perfumeName: $0.name, brandName: $0.brand) })
             likedKeys = []
+        }
+    }
+
+    private func mergeCollection(
+        remote: [CollectedPerfume],
+        cached: [CollectedPerfume]
+    ) -> [CollectedPerfume] {
+        var seenIDs = Set<String>()
+        return (remote + cached).filter { perfume in
+            seenIDs.insert(perfume.id).inserted
         }
     }
 
     // MARK: - 시향 기록 키 생성 (브랜드|이름 소문자)
 
-    private func noteKey(_ note: TastingNote) -> String {
-        perfumeKey(perfumeName: note.perfumeName, brandName: note.brandName)
+    private func noteKeys(_ note: TastingNote) -> Set<String> {
+        perfumeKeys(perfumeName: note.perfumeName, brandName: note.brandName)
     }
 
-    func perfumeKey(perfumeName: String, brandName: String) -> String {
+    private func uniqueLatestNotes(from notes: [TastingNote]) -> [TastingNote] {
+        var seenKeys = Set<String>()
+        return notes.filter { note in
+            let key = primaryPerfumeKey(perfumeName: note.perfumeName, brandName: note.brandName)
+            return seenKeys.insert(key).inserted
+        }
+    }
+
+    private func perfumeKeys(perfumeName: String, brandName: String) -> Set<String> {
+        [
+            primaryPerfumeKey(perfumeName: perfumeName, brandName: brandName),
+            primaryPerfumeKey(
+                perfumeName: PerfumePresentationSupport.displayPerfumeName(perfumeName),
+                brandName: PerfumePresentationSupport.displayBrand(brandName)
+            )
+        ]
+    }
+
+    private func primaryPerfumeKey(perfumeName: String, brandName: String) -> String {
         let normalizedBrand = brandName
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteDetailView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteDetailView.swift
@@ -145,19 +145,14 @@ struct TastingNoteDetailView: View {
 
     private var perfumeInfoCard: some View {
         HStack(spacing: 14) {
-            Group {
-                if let urlString = currentNote.perfumeImageURL,
-                   let url = URL(string: urlString) {
-                    KFImage(url)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } else {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color(.systemGray6))
-                }
+            if let urlString = currentNote.perfumeImageURL,
+               let url = URL(string: urlString) {
+                KFImage(url)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 110, height: 110)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
             }
-            .frame(width: 110, height: 110)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(PerfumePresentationSupport.displayBrand(currentNote.brandName))

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteFormView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteFormView.swift
@@ -7,7 +7,6 @@
 
 // MARK: - 등록 / 수정 화면
 import SwiftUI
-import Kingfisher
 
 struct TastingNoteFormView: View {
 
@@ -28,41 +27,16 @@ struct TastingNoteFormView: View {
             headerView
 
             ScrollView(showsIndicators: false) {
-                ScrollViewReader { proxy in
-                    VStack(alignment: .leading, spacing: 32) {
-                        // 수정 모드: 검색창 숨기고 읽기 전용 향수 카드 표시
-                        if vm.isEditMode {
-                            if let fragrance = vm.displayCardFragrance {
-                                editModeFragranceCard(fragrance)
-                            }
-                        } else {
-                            // 등록 모드: 기존 검색 섹션 유지
-                            searchSection
-                                .zIndex(10)
-                                .id("formTop")
-
-                            if let fragrance = vm.displayCardFragrance {
-                                selectedCard(fragrance)
-                            }
-                        }
-
-                        ratingSection(title: "향 선호도", value: $vm.rating, label: vm.rating.ratingLabel)
-                        moodTagSection
-                        memoSection
-                        Spacer().frame(height: 8)
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.top, vm.isEditMode ? 24 : 8)
-                    .padding(.bottom, 16)
-                    // 향수 선택 시 상단으로 스크롤 (등록 모드에서만)
-                    .onChange(of: vm.selectedFragrance?.id) { _ in
-                        if !vm.isEditMode {
-                            withAnimation(.easeOut(duration: 0.3)) {
-                                proxy.scrollTo("formTop", anchor: .top)
-                            }
-                        }
-                    }
+                VStack(alignment: .leading, spacing: 28) {
+                    perfumeInputSection
+                    ratingSection(title: "향 선호도", value: $vm.rating, label: vm.rating.ratingLabel)
+                    moodTagSection
+                    memoSection
+                    Spacer().frame(height: 8)
                 }
+                .padding(.horizontal, 20)
+                .padding(.top, 4)
+                .padding(.bottom, 16)
             }
 
             // 하단 버튼 바 — VStack 안에 배치해 스크롤 콘텐츠가 뒤로 보이지 않도록
@@ -103,222 +77,66 @@ struct TastingNoteFormView: View {
             }
         }
         .padding(.horizontal, 20)
-        .padding(.top, 14)
-        .padding(.bottom, 20)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
     }
 
-    // MARK: - 검색 섹션
+    // MARK: - 시향 향수 입력
 
-    private var searchSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("향수 명")
+    private var perfumeInputSection: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            Text("시향 향수")
                 .font(.system(size: 17, weight: .semibold))
 
-            ZStack(alignment: .top) {
-                searchField
+            formTextField(
+                title: "향수 명",
+                placeholder: "향수 명을 입력하세요",
+                text: $vm.perfumeName
+            )
 
-                if vm.isSearchResultVisible {
-                    searchDropdown.padding(.top, 74).zIndex(20)
-                }
-            }
-
-            if let guide = vm.searchGuideMessage, !guide.isEmpty {
-                Text(guide)
-                    .font(.system(size: 13))
-                    .foregroundColor(.secondary)
-                    .padding(.top, 2)
-            }
+            formTextField(
+                title: "브랜드",
+                placeholder: "향수 브랜드를 입력하세요",
+                text: $vm.brandName
+            )
         }
     }
 
-    private var searchField: some View {
-        HStack(spacing: 10) {
-            TextField("향수 명을 입력해주세요", text: $vm.searchText)
-                .font(.system(size: 15))
-                .submitLabel(.search)
-                .onSubmit { vm.searchButtonTapped() }
-
-            Button("검색") { vm.searchButtonTapped() }
-                .font(.system(size: 15, weight: .semibold))
+    private func formTextField(
+        title: String,
+        placeholder: String,
+        text: Binding<String>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text(title)
+                .font(.system(size: 14, weight: .regular))
                 .foregroundColor(.primary)
-        }
-        .padding(.horizontal, 16)
-        .frame(height: 60)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color(.systemGray4), lineWidth: 1)
-        )
-    }
 
-    // MARK: - 검색 결과 드롭다운
-
-    private var searchDropdown: some View {
-        VStack(spacing: 0) {
-            if vm.isSearching {
-                HStack { Spacer(); ProgressView(); Spacer() }.padding(.vertical, 20)
-            } else if vm.searchResults.isEmpty {
-                Text("검색 결과가 없어요")
-                    .font(.system(size: 14)).foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity).padding(.vertical, 20)
-            } else {
-                ForEach(Array(vm.searchResults.enumerated()), id: \.element.id) { idx, fragrance in
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.15)) { vm.selectFragrance(fragrance) }
-                    } label: {
-                        searchResultRow(fragrance)
-                    }
-                    .buttonStyle(.plain)
-
-                    if idx < vm.searchResults.count - 1 {
-                        Divider().padding(.leading, 72)
-                    }
-                }
-            }
-        }
-        .background(Color(.systemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color(.systemGray5), lineWidth: 1))
-        .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 4)
-    }
-
-    /// 검색 결과 행 — 한국어 이름/브랜드 우선 표시
-    private func searchResultRow(_ fragrance: FragellaFragrance) -> some View {
-        HStack(spacing: 12) {
-            // 썸네일 (이미지 없는 결과는 API에서 이미 필터됨)
-            KFImage(URL(string: fragrance.imageURL ?? ""))
-                .placeholder {
-                    RoundedRectangle(cornerRadius: 8).fill(Color(.systemGray6))
-                }
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 48, height: 48)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-
-            VStack(alignment: .leading, spacing: 4) {
-                // 한국어 이름 우선, 없으면 영문
-                Text(fragrance.displayName)
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primary)
-
-                HStack(spacing: 4) {
-                    // 한국어 브랜드 우선
-                    Text(fragrance.displayBrand)
-                        .font(.system(size: 13)).foregroundColor(.secondary)
-
-                    if !fragrance.mainAccords.isEmpty {
-                        Text("|").font(.system(size: 13)).foregroundColor(Color(.systemGray4))
-
-                        ForEach(fragrance.mainAccords.prefix(2), id: \.self) { accord in
-                            HStack(spacing: 3) {
-                                Circle().frame(width: 4, height: 4).foregroundColor(accord.accordColor)
-                                Text(accord).font(.system(size: 13)).foregroundColor(.secondary)
-                            }
-                        }
-                    }
-                }
-            }
-            Spacer()
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 12)
-    }
-
-    // MARK: - 선택된 향수 카드
-
-    private func selectedCard(_ fragrance: FragellaFragrance) -> some View {
-        HStack(spacing: 14) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 10).fill(Color(.systemGray6))
-                if let url = fragrance.imageURL.flatMap(URL.init) {
-                    KFImage(url).resizable().aspectRatio(contentMode: .fill)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                }
-            }
-            .frame(width: 80, height: 80)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(fragrance.displayBrand)
-                    .font(.system(size: 12)).foregroundColor(.secondary)
-                Text(fragrance.displayName)
-                    .font(.system(size: 16, weight: .semibold)).foregroundColor(.primary)
-                HStack(spacing: 6) {
-                    ForEach(fragrance.mainAccords.prefix(3), id: \.self) { a in
-                        HStack(spacing: 3) {
-                            Circle().frame(width: 5, height: 5).foregroundColor(a.accordColor)
-                            Text(a).font(.system(size: 13)).foregroundColor(.secondary)
-                        }
-                    }
-                }
-            }
-            Spacer()
-
-            Button { withAnimation { vm.clearSelectedFragrance() } } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primary)
-                    .frame(width: 32, height: 32)
-            }
-        }
-        .padding(14)
-        .background(Color(.systemGray6).opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-    }
-
-    // MARK: - 수정 모드 전용 향수 카드 (읽기 전용, x버튼 없음)
-
-    private func editModeFragranceCard(_ fragrance: FragellaFragrance) -> some View {
-        HStack(spacing: 14) {
-            // 향수 이미지
-            ZStack {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color(.systemGray6))
-                if let url = fragrance.imageURL.flatMap(URL.init) {
-                    KFImage(url)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-            }
-            .frame(width: 110, height: 110)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text(fragrance.displayBrand)
-                    .font(.system(size: 14))
-                    .foregroundColor(.secondary)
-
-                Text(fragrance.displayName)
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundColor(.primary)
-
-                if !fragrance.mainAccords.isEmpty {
-                    HStack(spacing: 6) {
-                        ForEach(fragrance.mainAccords.prefix(3), id: \.self) { accord in
-                            HStack(spacing: 4) {
-                                Circle()
-                                    .frame(width: 5, height: 5)
-                                    .foregroundColor(accord.accordColor)
-                                Text(accord)
-                                    .font(.system(size: 13))
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                    }
-                }
-            }
-            Spacer()
+            TextField(placeholder, text: text)
+                .font(.system(size: 16))
+                .submitLabel(.next)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(.horizontal, 16)
+                .frame(height: 50)
+                .background(Color(.systemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(.systemGray4), lineWidth: 1)
+                )
         }
     }
 
     // MARK: - 별점 섹션
 
     private func ratingSection(title: String, value: Binding<Int>, label: String) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 11) {
             Text(title).font(.system(size: 17, weight: .semibold))
 
             HStack(spacing: 4) {
                 ForEach(1...5, id: \.self) { star in
                     Image(systemName: star <= value.wrappedValue ? "star.fill" : "star")
-                        .font(.system(size: 32))
+                        .font(.system(size: 31))
                         .foregroundColor(star <= value.wrappedValue ? .primary : Color(.systemGray4))
                         .onTapGesture { value.wrappedValue = star }
                 }
@@ -348,12 +166,12 @@ struct TastingNoteFormView: View {
     }
 
     private var moodTagSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 11) {
             Text("분위기&이미지").font(.system(size: 17, weight: .semibold))
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 7) {
                 ForEach(moodTagRows.indices, id: \.self) { rowIndex in
-                    HStack(spacing: 8) {
+                    HStack(spacing: 7) {
                         ForEach(moodTagRows[rowIndex], id: \.self) { tag in
                             MoodChip(title: tag, isSelected: vm.selectedMoodTags.contains(tag)) {
                                 vm.toggleMoodTag(tag)
@@ -369,7 +187,7 @@ struct TastingNoteFormView: View {
     // MARK: - 시향 메모
 
     private var memoSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 11) {
             Text("시향 메모").font(.system(size: 17, weight: .semibold))
 
             ZStack(alignment: .bottomTrailing) {
@@ -383,7 +201,7 @@ struct TastingNoteFormView: View {
                     }
                     TextEditor(text: $vm.memo)
                         .font(.system(size: 15))
-                        .frame(minHeight: 140)
+                        .frame(minHeight: 138)
                         .padding(.horizontal, 8).padding(.top, 8)
                         .onChange(of: vm.memo) { v in
                             if v.count > 2000 { vm.memo = String(v.prefix(2000)) }
@@ -407,7 +225,7 @@ struct TastingNoteFormView: View {
             Button { vm.reset() } label: {
                 Text("초기화")
                     .font(.system(size: 16, weight: .semibold)).foregroundColor(.primary)
-                    .frame(maxWidth: .infinity).frame(height: 56)
+                    .frame(maxWidth: .infinity).frame(height: 52)
                     .background(Color(.systemGray6))
                     .clipShape(RoundedRectangle(cornerRadius: 12))
             }
@@ -420,15 +238,15 @@ struct TastingNoteFormView: View {
                             .font(.system(size: 16, weight: .semibold)).foregroundColor(.white)
                     }
                 }
-                .frame(maxWidth: .infinity).frame(height: 56)
+                .frame(maxWidth: .infinity).frame(height: 52)
                 .background(vm.canSave ? Color.black : Color(.systemGray4))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .disabled(!vm.canSave || vm.isSaving)
         }
         .padding(.horizontal, 20)
-        .padding(.top, 12)
-        .padding(.bottom, 20)
+        .padding(.top, 10)
+        .padding(.bottom, 18)
         .background(
             Color(.systemBackground)
                 .overlay(alignment: .top) {
@@ -451,9 +269,9 @@ struct MoodChip: View {
     var body: some View {
         Button(action: onTap) {
             Text(title)
-                .font(.system(size: 14))
+                .font(.system(size: 13))
                 .foregroundColor(isSelected ? .white : Color(.label))
-                .padding(.horizontal, 14).padding(.vertical, 8)
+                .padding(.horizontal, 13).padding(.vertical, 7)
                 .background(isSelected ? Color.black : Color.clear)
                 .clipShape(Capsule())
                 .overlay(Capsule().stroke(isSelected ? Color.clear : Color(.systemGray4), lineWidth: 1))

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteView.swift
@@ -7,7 +7,6 @@
 
 // MARK: - 목록 화면 (data X / data O 상태)
 import SwiftUI
-import Kingfisher
 
 struct TastingNoteView: View {
 
@@ -44,13 +43,14 @@ struct TastingNoteView: View {
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
 
-                addButton
-                    .padding(.trailing, 20)
-                    .padding(.bottom, 24)
+                if !viewModel.isDeleteMode {
+                    addButton
+                        .padding(.trailing, 20)
+                        .padding(.bottom, 24)
+                }
             }
             .toolbar(.hidden, for: .navigationBar)
             .fullScreenCover(isPresented: $viewModel.showFormSheet, onDismiss: {
-                // 폼 닫힌 직후 강제 새로고침 (리스너 지연 대비)
                 Task { await viewModel.reload() }
             }) {
                 TastingNoteSceneFactory.makeFormView { perfumeName in
@@ -63,7 +63,7 @@ struct TastingNoteView: View {
                 }
                 Button("취소", role: .cancel) { }
             } message: {
-                Text("이 시향 기록을 삭제할까요?\n삭제 후 복구할 수 없어요.")
+                Text(deleteAlertMessage)
             }
             .alert("오류", isPresented: Binding(
                 get: { viewModel.errorMessage != nil },
@@ -73,40 +73,90 @@ struct TastingNoteView: View {
             } message: {
                 Text(viewModel.errorMessage ?? "")
             }
+            .onAppear {
+                Task { await viewModel.reloadFromLocal() }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .tastingNotesDidChange)) { _ in
+                Task { await viewModel.reloadFromLocal() }
+            }
         }
         .animation(.easeInOut(duration: 0.2), value: viewModel.toastMessage)
     }
 
+    @ViewBuilder
     private var headerView: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            // 타이틀 + 삭제 버튼
+        if viewModel.isDeleteMode {
+            editHeaderView
+        } else {
+            normalHeaderView
+        }
+    }
+
+    private var normalHeaderView: some View {
+        VStack(alignment: .leading, spacing: 22) {
             HStack(alignment: .center) {
-                Text(viewModel.perfumeScope?.title ?? "시향 기록")
-                    .font(.system(size: 30, weight: .bold))
+                Text(viewModel.perfumeScope?.title ?? "시향기")
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundColor(.black)
 
                 Spacer()
 
-                Button(viewModel.isDeleteMode ? "완료" : "삭제") {
+                Button("편집") {
                     guard !viewModel.isEmpty else { return }
                     viewModel.toggleDeleteMode()
                 }
-                .font(.system(size: 17, weight: .medium))
-                .foregroundColor(.primary)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(Color(.systemGray))
                 .disabled(viewModel.isEmpty)
                 .opacity(viewModel.isEmpty ? 0.35 : 1)
             }
 
-            // 전체 / 보유 향수 / 좋아요 향수 필터 칩
-            HStack(spacing: 10) {
+            HStack(spacing: 9) {
                 filterChip(title: "전체 시향기", filter: .all)
                 filterChip(title: "보유 향수", filter: .owned)
-                filterChip(title: "좋아요 향수", filter: .liked)
-                Spacer()
+                filterChip(title: "LIKE 향수", filter: .liked)
+                Spacer(minLength: 0)
             }
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, 24)
         .padding(.top, 22)
-        .padding(.bottom, 16)
+        .padding(.bottom, 9)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color(.systemGray5))
+                .frame(height: 0.6)
+        }
+    }
+
+    private var editHeaderView: some View {
+        HStack(spacing: 10) {
+            Button {
+                viewModel.toggleDeleteMode()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 26, weight: .medium))
+                    .foregroundColor(.black)
+                    .frame(width: 44, height: 44, alignment: .leading)
+            }
+
+            Text("시향 기록 편집")
+                .font(.system(size: 25, weight: .bold))
+                .foregroundColor(.black)
+
+            Spacer()
+
+            Button("삭제") {
+                viewModel.requestDeleteSelected()
+            }
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundColor(Color(red: 0.92, green: 0.16, blue: 0.14))
+            .opacity(viewModel.hasSelectedNotes ? 1 : 0.35)
+            .disabled(!viewModel.hasSelectedNotes)
+        }
+        .padding(.leading, 20)
+        .padding(.trailing, 24)
+        .padding(.top, 22)
+        .padding(.bottom, 18)
     }
 
     private var emptyStateView: some View {
@@ -135,7 +185,7 @@ struct TastingNoteView: View {
         switch viewModel.selectedFilter {
         case .all:    return "아직 작성한 시향기가 없어요"
         case .owned:  return "보유 향수 시향기가 없어요"
-        case .liked:  return "좋아요 향수 시향기가 없어요"
+        case .liked:  return "LIKE 향수 시향기가 없어요"
         }
     }
 
@@ -146,33 +196,42 @@ struct TastingNoteView: View {
         switch viewModel.selectedFilter {
         case .all:    return "+ 버튼을 눌러 첫 시향기를 작성해 주세요"
         case .owned:  return "보유 향수에 등록된 향수의 시향기만 여기에 표시돼요"
-        case .liked:  return "좋아요를 누른 향수의 시향기만 여기에 표시돼요"
+        case .liked:  return "LIKE를 누른 향수의 시향기만 여기에 표시돼요"
         }
     }
 
     private var noteListView: some View {
         ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(spacing: 0) {
                 ForEach(viewModel.filteredNotes) { note in
-                    NavigationLink {
-                        TastingNoteDetailView(note: note, viewModel: viewModel)
-                    } label: {
-                        TastingNoteRowView(
-                            note: note,
-                            isDeleteMode: viewModel.isDeleteMode,
-                            onDelete: { viewModel.requestDelete(note) }
-                        )
+                    if viewModel.isDeleteMode {
+                        Button {
+                            viewModel.toggleNoteSelection(note)
+                        } label: {
+                            TastingNoteEditRowView(
+                                note: note,
+                                isSelected: viewModel.isSelected(note)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        NavigationLink {
+                            TastingNoteDetailView(note: note, viewModel: viewModel)
+                        } label: {
+                            TastingNoteTextRowView(note: note)
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
 
                     Divider()
-                        .padding(.leading, viewModel.isDeleteMode ? 96 : 88)
+                        .padding(.leading, viewModel.isDeleteMode ? 86 : 24)
                         .opacity(0.55)
                 }
 
                 Spacer()
-                    .frame(height: 120)
+                    .frame(height: viewModel.isDeleteMode ? 110 : 140)
             }
+            .padding(.top, viewModel.isDeleteMode ? 0 : 10)
         }
     }
 
@@ -180,20 +239,26 @@ struct TastingNoteView: View {
         Button {
             viewModel.showFormSheet = true
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: 10) {
                 Image(systemName: "plus")
-                    .font(.system(size: 16, weight: .bold))
+                    .font(.system(size: 22, weight: .regular))
 
                 Text("시향기 등록")
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(.system(size: 18, weight: .semibold))
             }
             .foregroundColor(.white)
-            .padding(.horizontal, 26)
-            .frame(height: 56)
+            .padding(.horizontal, 22)
+            .frame(height: 52)
             .background(Color.black)
             .clipShape(Capsule())
             .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 4)
         }
+    }
+
+    private var deleteAlertMessage: String {
+        viewModel.hasSelectedNotes
+        ? "선택한 시향 기록을 삭제할까요?\n삭제 후 복구할 수 없어요."
+        : "이 시향 기록을 삭제할까요?\n삭제 후 복구할 수 없어요."
     }
 
     /// 시향기 필터 칩 버튼
@@ -203,13 +268,18 @@ struct TastingNoteView: View {
             viewModel.selectFilter(filter)
         } label: {
             Text(title)
-                .font(.system(size: 14, weight: .medium))
+                .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(isSelected ? .white : .primary)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 14)
+                .frame(height: 34)
                 .background(isSelected ? Color.black : Color(.systemBackground))
                 .clipShape(Capsule())
-                .overlay(Capsule().stroke(isSelected ? Color.clear : Color(.systemGray3), lineWidth: 1))
+                .overlay(
+                    Capsule()
+                        .stroke(isSelected ? Color.clear : Color(.systemGray), lineWidth: 1.5)
+                )
         }
     }
 
@@ -225,81 +295,84 @@ struct TastingNoteView: View {
     }
 }
 
-struct TastingNoteRowView: View {
+private struct TastingNoteTextRowView: View {
 
     let note: TastingNote
-    let isDeleteMode: Bool
-    let onDelete: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
-            if isDeleteMode {
-                Button(action: onDelete) {
-                    Image(systemName: "minus.circle.fill")
-                        .font(.system(size: 22))
-                        .foregroundColor(.red)
-                }
-                .padding(.leading, 20)
-            }
+        VStack(alignment: .leading, spacing: 6) {
+            Text(PerfumePresentationSupport.displayPerfumeName(note.perfumeName))
+                .font(.system(size: 17, weight: .regular))
+                .foregroundColor(.black)
+                .lineLimit(1)
 
-            perfumeThumbnail
+            Text(PerfumePresentationSupport.displayBrand(note.brandName))
+                .font(.system(size: 15, weight: .regular))
+                .foregroundColor(Color(.systemGray))
+                .lineLimit(1)
 
-            VStack(alignment: .leading, spacing: 4) {
+            Text(note.updatedAt.tastingNoteFormat)
+                .font(.system(size: 14, weight: .regular))
+                .foregroundColor(Color(.systemGray3))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+}
+
+private struct TastingNoteEditRowView: View {
+
+    let note: TastingNote
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            checkbox
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 6) {
                 Text(PerfumePresentationSupport.displayPerfumeName(note.perfumeName))
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primary)
+                    .font(.system(size: 17, weight: .regular))
+                    .foregroundColor(.black)
                     .lineLimit(1)
 
-                HStack(spacing: 4) {
-                    Text(PerfumePresentationSupport.displayBrand(note.brandName))
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
+                Text(PerfumePresentationSupport.displayBrand(note.brandName))
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundColor(Color(.systemGray))
+                    .lineLimit(1)
 
-                    if !note.mainAccords.isEmpty {
-                        Text("|")
-                            .font(.system(size: 13))
-                            .foregroundColor(Color(.systemGray4))
-
-                        ForEach(Array(PerfumePresentationSupport.displayAccords(Array(note.mainAccords.prefix(2))).enumerated()), id: \.offset) { _, accord in
-                            HStack(spacing: 3) {
-                                Circle()
-                                    .frame(width: 4, height: 4)
-                                    .foregroundColor(accord.accordColor)
-
-                                Text(accord)
-                                    .font(.system(size: 13))
-                                    .foregroundColor(Color(.systemGray4))
-                            }
-                        }
-                    }
-                }
                 Text(note.updatedAt.tastingNoteFormat)
-                    .font(.system(size: 12))
-                    .foregroundColor(Color(.tertiaryLabel))
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundColor(Color(.systemGray3))
+                    .lineLimit(1)
             }
 
-            Spacer()
+            Spacer(minLength: 0)
         }
-        .padding(.vertical, 14)
-        .padding(.leading, isDeleteMode ? 0 : 20)
-        .padding(.trailing, 20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 20)
+        .padding(.trailing, 24)
+        .padding(.vertical, 10)
         .contentShape(Rectangle())
     }
 
-    private var perfumeThumbnail: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color(.systemGray6))
-
-            if let urlString = note.perfumeImageURL,
-               let url = URL(string: urlString) {
-                KFImage(url)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .padding(6)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+    private var checkbox: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .stroke(isSelected ? Color.black : Color(.systemGray), lineWidth: 1.5)
+            .frame(width: 25, height: 25)
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.black)
+                        .overlay {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundColor(.white)
+                        }
+                }
             }
-        }
-        .frame(width: 56, height: 56)
     }
 }

--- a/Sniff/Sniff.xcdatamodeld/Sniff.xcdatamodel/contents
+++ b/Sniff/Sniff.xcdatamodeld/Sniff.xcdatamodel/contents
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
+    <entity name="LocalTastingNoteEntity" representedClassName="LocalTastingNoteEntity" syncable="YES">
+        <attribute name="brandName" optional="NO" attributeType="String"/>
+        <attribute name="concentration" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="NO" attributeType="String"/>
+        <attribute name="isDeletedPending" optional="NO" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="mainAccordsJSON" optional="NO" attributeType="String" defaultValueString="[]"/>
+        <attribute name="memo" optional="NO" attributeType="String" defaultValueString=""/>
+        <attribute name="moodTagsJSON" optional="NO" attributeType="String" defaultValueString="[]"/>
+        <attribute name="perfumeImageURL" optional="YES" attributeType="String"/>
+        <attribute name="perfumeName" optional="NO" attributeType="String"/>
+        <attribute name="rating" optional="NO" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="String"/>
+        <attribute name="revisitDesire" optional="YES" attributeType="String"/>
+        <attribute name="syncStatus" optional="NO" attributeType="String" defaultValueString="pending"/>
+        <attribute name="updatedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <elements>
+        <element name="LocalTastingNoteEntity" positionX="-63" positionY="-18" width="128" height="254"/>
+    </elements>
 </model>

--- a/Sniff/Utils/FragranceProfileText.swift
+++ b/Sniff/Utils/FragranceProfileText.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum FragranceProfileText {
 
-    static func displayTitle(for families: [String]) -> String {
+    nonisolated static func displayTitle(for families: [String]) -> String {
         guard let firstFamily = normalizedFamilies(from: families).first else {
             return "취향을 분석하는 중이에요"
         }
@@ -23,7 +23,7 @@ enum FragranceProfileText {
         }
     }
 
-    static func familySummary(for families: [String]) -> String {
+    nonisolated static func familySummary(for families: [String]) -> String {
         let topFamilies = Array(normalizedFamilies(from: families).prefix(2))
 
         switch topFamilies.count {
@@ -36,7 +36,7 @@ enum FragranceProfileText {
         }
     }
 
-    static func majorFamilySummary(for families: [String]) -> String {
+    nonisolated static func majorFamilySummary(for families: [String]) -> String {
         let groups = normalizedFamilies(from: families)
             .compactMap(majorGroup(for:))
             .reduce(into: [String]()) { result, group in
@@ -57,11 +57,11 @@ enum FragranceProfileText {
         }
     }
 
-    static func leadingFamily(from families: [String]) -> String? {
+    nonisolated static func leadingFamily(from families: [String]) -> String? {
         normalizedFamilies(from: families).first
     }
 
-    static func normalizedFamilies(from families: [String]) -> [String] {
+    nonisolated static func normalizedFamilies(from families: [String]) -> [String] {
         var seen = Set<String>()
 
         return families
@@ -69,7 +69,7 @@ enum FragranceProfileText {
             .filter { seen.insert($0).inserted }
     }
 
-    private static func majorGroup(for family: String) -> String? {
+    nonisolated private static func majorGroup(for family: String) -> String? {
         switch family {
         case "Citrus", "Fruity", "Green", "Water", "Aromatic":
             return "Fresh"

--- a/Sniff/firestore.rules
+++ b/Sniff/firestore.rules
@@ -1,0 +1,37 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ─────────────────────────────────────────────
+    // 사용자 문서 및 서브컬렉션
+    // 본인 UID 와 일치하는 경우에만 읽기/쓰기 허용
+    // ─────────────────────────────────────────────
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+
+      // 향수 컬렉션 (향수 등록)
+      match /collection/{perfumeId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      // 좋아요 목록
+      match /likes/{perfumeId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      // 시향 기록
+      match /tastingRecords/{recordId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+    }
+
+    // ─────────────────────────────────────────────
+    // 향수 카탈로그 (전체 인증 사용자 읽기 전용)
+    // ─────────────────────────────────────────────
+    match /perfumes/{perfumeId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+  }
+}


### PR DESCRIPTION
- 시향 기록을 CoreData에 로컬 저장하도록 추가
- 오프라인 상태에서도 시향 기록 등록/조회 가능하도록 수정
- 전체 시향기 / 보유 향수 / LIKE 향수 필터 목록 동작 수정
- 시향 기록 등록/상세/편집 화면 UI를 와이어프레임 기준으로 조정