### PR TITLE
feat: 보유 향수 및 LIKE 저장 제한 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+This is an Xcode project. Open `Sniff.xcodeproj` and build/run with Xcode (⌘R). There is no CLI build, lint, or test command — all development is done through Xcode.
+
+## API Keys Setup
+
+Before building, copy `Sniff/Config/Secrets.xcconfig.example` to `Sniff/Config/Secrets.xcconfig` and fill in the real keys:
+
+```
+FRAGELLA_API_KEY = <your key>
+GEMINI_API_KEY   = <your key>
+```
+
+`Secrets.xcconfig` is gitignored. Keys are read at runtime via `AppSecrets.geminiAPIKey()` / `AppSecrets.fragellaAPIKey()`, which pull from `Info.plist` entries injected by the xcconfig. Never hardcode keys directly in source.
+
+## Architecture
+
+Clean Architecture with MVVM-style presentation layer.
+
+```
+Domain/          ← protocols, models, use cases (no external imports)
+Data/            ← concrete implementations
+  Remote/API/    ← Fragella (perfume catalog), Gemini (taste analysis + name translation)
+  Remote/Firebase/ ← FirestoreService (user data), AuthService
+  Local/         ← CoreData (tasting notes), UserDefaults (search history, Fragella cache)
+  Repository/    ← bridges Domain protocols to Data services
+Presentation/
+  common/Tab/    ← one folder per screen (Home, Search, TastingNote, MyPage, PerfumeDetail, Onboarding, Login, Settings, Splash)
+  common/Components/ ← shared SwiftUI views
+  common/DesignSystem/ ← Color/Font extensions (Color.sniffBeige, Font.sniffTitle, etc.)
+App/
+  AppStateManager.swift   ← top-level state machine (splash→login→onboarding→main)
+  DI/AppDependencyContainer.swift ← singleton DI root; SceneFactory files wire VMs
+Localization/
+  UIStrings/AppStrings+*.swift    ← all user-facing strings
+  PerfumeTranslation/             ← Korean transliteration dictionary
+```
+
+## Dependency Injection
+
+`AppDependencyContainer.shared` is the single DI root. Singletons (`AuthService`, `FirestoreService`, `CoreDataStack`) are lazy properties. Per-request objects are created by `make*()` factory methods. Each screen gets a `*SceneFactory` in `App/DI/` that calls the container and passes dependencies to the ViewModel.
+
+## Data Flow
+
+- **Recommendation**: `RecommendPerfumesUseCase` → `RecommendationEngine` (RxSwift `Single`) → `PerfumeScorer` scores candidates from `PerfumeCatalogRepository` (backed by `FragellaService`).
+- **Tasting notes**: `LocalTastingNoteRepository` writes to CoreData first, then syncs to Firestore's `users/{uid}/tastingRecords`. Sync status transitions: `pending` → `synced` / `failed`.
+- **Taste analysis**: After saving enough tasting records (≥5, memo ≥20 chars), `LocalTastingNoteRepository` triggers `UserTasteRepository.reanalyzeTasteFromHistory()`, which calls `GeminiTasteAnalysisService` and persists the result to Firestore.
+- **Perfume name translation**: `PerfumeNameTranslationService` — local dictionary first, Gemini fallback for unknowns. Results are in-memory cached.
+
+## Reactive Pattern
+
+`RecommendationEngine` and `FragellaService` use **RxSwift** (`Single`). All other async work uses **Swift Concurrency** (`async/await`). When bridging RxSwift to async contexts, use `RxSwift+Async.swift` helpers.
+
+## Firestore Schema
+
+User document: `users/{uid}` with sub-collections:
+- `collection/` — owned perfumes
+- `likes/` — liked perfumes
+- `tastingRecords/` — synced tasting notes
+
+Firestore security rules reject `null` optional fields, so `nil` Swift optionals must be omitted from write dictionaries entirely (not set to `NSNull`).
+
+## Localization
+
+All UI strings live in `Localization/UIStrings/AppStrings+*.swift`. Add new strings there, not inline. Korean transliteration data is split across `PerfumeKoreanTranslator+Data.swift` (word/brand dictionaries) and `PerfumeKoreanTranslator+Logic.swift` (matching logic).

--- a/Sniff/Data/Local/CollectionUsageLimiter.swift
+++ b/Sniff/Data/Local/CollectionUsageLimiter.swift
@@ -1,0 +1,120 @@
+//
+//  CollectionUsageLimiter.swift
+//  Sniff
+//
+
+import Foundation
+
+enum CollectionUsageLimitError: LocalizedError {
+    case monthlyCollectionLimitReached
+    case dailyLikeLimitReached
+    case totalLikeLimitReached
+
+    var errorDescription: String? {
+        switch self {
+        case .monthlyCollectionLimitReached:
+            return AppStrings.CollectionUsageLimits.monthlyCollectionLimitReached
+        case .dailyLikeLimitReached:
+            return AppStrings.CollectionUsageLimits.dailyLikeLimitReached
+        case .totalLikeLimitReached:
+            return AppStrings.CollectionUsageLimits.totalLikeLimitReached
+        }
+    }
+}
+
+final class CollectionUsageLimiter {
+    static let shared = CollectionUsageLimiter()
+
+    private enum Limit {
+        static let monthlyCollectionChanges = 5
+        static let dailyLikes = 10
+        static let totalLikes = 100
+    }
+
+    private enum Key {
+        static let collectionMonth = "collectionUsageLimiter.collectionMonth"
+        static let collectionCount = "collectionUsageLimiter.collectionCount"
+        static let likeDay = "collectionUsageLimiter.likeDay"
+        static let likeCount = "collectionUsageLimiter.likeCount"
+    }
+
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var monthlyCollectionLimit: Int { Limit.monthlyCollectionChanges }
+
+    func currentMonthlyCollectionUsage(date: Date = Date()) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        resetCollectionMonthIfNeeded(date: date)
+        return defaults.integer(forKey: Key.collectionCount)
+    }
+
+    func validateCollectionChange(date: Date = Date()) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        resetCollectionMonthIfNeeded(date: date)
+
+        guard defaults.integer(forKey: Key.collectionCount) < Limit.monthlyCollectionChanges else {
+            throw CollectionUsageLimitError.monthlyCollectionLimitReached
+        }
+    }
+
+    func recordCollectionChange(date: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+        resetCollectionMonthIfNeeded(date: date)
+        defaults.set(defaults.integer(forKey: Key.collectionCount) + 1, forKey: Key.collectionCount)
+    }
+
+    func validateLikeAddition(currentTotalLikes: Int, date: Date = Date()) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        resetLikeDayIfNeeded(date: date)
+
+        guard currentTotalLikes < Limit.totalLikes else {
+            throw CollectionUsageLimitError.totalLikeLimitReached
+        }
+
+        guard defaults.integer(forKey: Key.likeCount) < Limit.dailyLikes else {
+            throw CollectionUsageLimitError.dailyLikeLimitReached
+        }
+    }
+
+    func recordLikeAddition(date: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+        resetLikeDayIfNeeded(date: date)
+        defaults.set(defaults.integer(forKey: Key.likeCount) + 1, forKey: Key.likeCount)
+    }
+}
+
+private extension CollectionUsageLimiter {
+    func resetCollectionMonthIfNeeded(date: Date) {
+        let key = monthKey(for: date)
+        guard defaults.string(forKey: Key.collectionMonth) != key else { return }
+        defaults.set(key, forKey: Key.collectionMonth)
+        defaults.set(0, forKey: Key.collectionCount)
+    }
+
+    func resetLikeDayIfNeeded(date: Date) {
+        let key = dayKey(for: date)
+        guard defaults.string(forKey: Key.likeDay) != key else { return }
+        defaults.set(key, forKey: Key.likeDay)
+        defaults.set(0, forKey: Key.likeCount)
+    }
+
+    func monthKey(for date: Date) -> String {
+        let components = Calendar.current.dateComponents([.year, .month], from: date)
+        return "\(components.year ?? 0)-\(components.month ?? 0)"
+    }
+
+    func dayKey(for date: Date) -> String {
+        let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        return "\(components.year ?? 0)-\(components.month ?? 0)-\(components.day ?? 0)"
+    }
+}

--- a/Sniff/Data/Local/LocalTastingNoteRepository.swift
+++ b/Sniff/Data/Local/LocalTastingNoteRepository.swift
@@ -187,10 +187,6 @@ final class LocalTastingNoteRepository {
             return existing
         }
 
-        if let duplicate = try findLatestDuplicate(perfumeName: note.perfumeName, brandName: note.brandName) {
-            return duplicate
-        }
-
         let entity = LocalTastingNoteEntity(context: context)
         entity.id = note.id ?? UUID().uuidString
         return entity
@@ -206,20 +202,6 @@ final class LocalTastingNoteRepository {
     private func findEntity(remoteID: String) throws -> LocalTastingNoteEntity? {
         let request = LocalTastingNoteEntity.fetchRequest()
         request.predicate = NSPredicate(format: "remoteID == %@", remoteID)
-        request.fetchLimit = 1
-        return try context.fetch(request).first
-    }
-
-    private func findLatestDuplicate(perfumeName: String, brandName: String) throws -> LocalTastingNoteEntity? {
-        let request = LocalTastingNoteEntity.fetchRequest()
-        request.predicate = NSPredicate(
-            format: "isDeletedPending == NO AND perfumeName ==[c] %@ AND brandName ==[c] %@",
-            perfumeName.trimmingCharacters(in: .whitespacesAndNewlines),
-            brandName.trimmingCharacters(in: .whitespacesAndNewlines)
-        )
-        request.sortDescriptors = [
-            NSSortDescriptor(key: #keyPath(LocalTastingNoteEntity.createdAt), ascending: false)
-        ]
         request.fetchLimit = 1
         return try context.fetch(request).first
     }

--- a/Sniff/Data/Local/RecommendationUpdateTracker.swift
+++ b/Sniff/Data/Local/RecommendationUpdateTracker.swift
@@ -1,0 +1,46 @@
+//
+//  RecommendationUpdateTracker.swift
+//  Sniff
+//
+
+import Foundation
+
+final class RecommendationUpdateTracker {
+
+    private let defaults = UserDefaults.standard
+    private let timestampsKey = "sniff.recommendation.updateTimestamps.v1"
+    private static let dailyLimit = 2
+
+    var todayUpdateCount: Int {
+        let startOfToday = Calendar.current.startOfDay(for: Date())
+        return storedTimestamps().filter { $0 >= startOfToday }.count
+    }
+
+    /// 이번 홈 로드가 공식 업데이트로 기록될 수 있는지 판단.
+    /// - count == 0: 당일 첫 업데이트 → 항상 허용 (온보딩 직후 포함)
+    /// - count == 1: 두 번째 업데이트 → 조건 충족 시만 허용
+    /// - count >= 2: 당일 한도 소진 → 불허
+    func canRecord(collectionCount: Int, tastingCount: Int) -> Bool {
+        let count = todayUpdateCount
+        guard count < Self.dailyLimit else { return false }
+        if count == 0 { return true }
+        return (collectionCount + tastingCount >= 3) || (tastingCount >= 5)
+    }
+
+    func recordUpdate() {
+        var timestamps = storedTimestamps()
+        timestamps.append(Date())
+        let cutoff = Calendar.current.startOfDay(for: Date()).addingTimeInterval(-24 * 3600)
+        timestamps = timestamps.filter { $0 >= cutoff }
+        guard let data = try? JSONEncoder().encode(timestamps) else { return }
+        defaults.set(data, forKey: timestampsKey)
+    }
+
+    private func storedTimestamps() -> [Date] {
+        guard
+            let data = defaults.data(forKey: timestampsKey),
+            let timestamps = try? JSONDecoder().decode([Date].self, from: data)
+        else { return [] }
+        return timestamps
+    }
+}

--- a/Sniff/Data/Remote/API/FragellaService.swift
+++ b/Sniff/Data/Remote/API/FragellaService.swift
@@ -76,6 +76,10 @@ final class FragellaService {
     }
 
     private func requestSearch(query: String, limit: Int) async throws -> [Perfume] {
+        guard query.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2 else {
+            return []
+        }
+
         let cacheKey = makeSearchCacheKey(query: query, limit: limit)
 
         if let cached = cachedSearch(for: cacheKey) {
@@ -140,43 +144,14 @@ final class FragellaService {
 
     private func cachedSearch(for key: String) -> [Perfume]? {
         cacheLock.lock()
-        defer { cacheLock.unlock() }
-
-        guard let entry = searchCache[key], !entry.isExpired(referenceDate: Date()) else {
-            searchCache[key] = nil
-            return cachedDiskSearch(for: key)
+        if let entry = searchCache[key], !entry.isExpired(referenceDate: Date()) {
+            let value = entry.value
+            cacheLock.unlock()
+            return value
         }
+        searchCache[key] = nil
+        cacheLock.unlock()
 
-        return entry.value
-    }
-
-    private func cachedDetail(for key: String) -> Perfume? {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
-
-        guard let entry = detailCache[key], !entry.isExpired(referenceDate: Date()) else {
-            detailCache[key] = nil
-            return cachedDiskDetail(for: key)
-        }
-
-        return entry.value
-    }
-
-    private func storeSearch(_ perfumes: [Perfume], responseData: Data, for key: String) {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
-        searchCache[key] = CacheEntry(value: perfumes, expiresAt: Date().addingTimeInterval(cacheTTL))
-        storeDiskResponse(responseData, for: key, storageKey: DiskCacheKey.searchResponses)
-    }
-
-    private func storeDetail(_ perfume: Perfume, responseData: Data, for key: String) {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
-        detailCache[key] = CacheEntry(value: perfume, expiresAt: Date().addingTimeInterval(cacheTTL))
-        storeDiskResponse(responseData, for: key, storageKey: DiskCacheKey.detailResponses)
-    }
-
-    private func cachedDiskSearch(for key: String) -> [Perfume]? {
         guard let data = cachedDiskResponse(for: key, storageKey: DiskCacheKey.searchResponses),
               let perfumes = try? FragellaResponseParser.parsePerfumeList(from: data)
         else {
@@ -184,11 +159,22 @@ final class FragellaService {
             return nil
         }
 
+        cacheLock.lock()
         searchCache[key] = CacheEntry(value: perfumes, expiresAt: Date().addingTimeInterval(cacheTTL))
+        cacheLock.unlock()
         return perfumes
     }
 
-    private func cachedDiskDetail(for key: String) -> Perfume? {
+    private func cachedDetail(for key: String) -> Perfume? {
+        cacheLock.lock()
+        if let entry = detailCache[key], !entry.isExpired(referenceDate: Date()) {
+            let value = entry.value
+            cacheLock.unlock()
+            return value
+        }
+        detailCache[key] = nil
+        cacheLock.unlock()
+
         guard let data = cachedDiskResponse(for: key, storageKey: DiskCacheKey.detailResponses),
               let perfume = try? FragellaResponseParser.parsePerfumeDetail(from: data)
         else {
@@ -196,8 +182,24 @@ final class FragellaService {
             return nil
         }
 
+        cacheLock.lock()
         detailCache[key] = CacheEntry(value: perfume, expiresAt: Date().addingTimeInterval(cacheTTL))
+        cacheLock.unlock()
         return perfume
+    }
+
+    private func storeSearch(_ perfumes: [Perfume], responseData: Data, for key: String) {
+        cacheLock.lock()
+        searchCache[key] = CacheEntry(value: perfumes, expiresAt: Date().addingTimeInterval(cacheTTL))
+        cacheLock.unlock()
+        storeDiskResponse(responseData, for: key, storageKey: DiskCacheKey.searchResponses)
+    }
+
+    private func storeDetail(_ perfume: Perfume, responseData: Data, for key: String) {
+        cacheLock.lock()
+        detailCache[key] = CacheEntry(value: perfume, expiresAt: Date().addingTimeInterval(cacheTTL))
+        cacheLock.unlock()
+        storeDiskResponse(responseData, for: key, storageKey: DiskCacheKey.detailResponses)
     }
 
     private func cachedDiskResponse(for key: String, storageKey: String) -> Data? {

--- a/Sniff/Data/Remote/Firebase/FirestoreService+VectorParsing.swift
+++ b/Sniff/Data/Remote/Firebase/FirestoreService+VectorParsing.swift
@@ -33,6 +33,12 @@ extension FirestoreService {
         let rawStrengths = data["accordStrengths"] as? [String: String] ?? [:]
         let accordStrengths = parseAccordStrengths(from: rawStrengths)
 
+        let seasonRanking: [SeasonRankingEntry] = (data["seasonRanking"] as? [[String: Any]] ?? [])
+            .compactMap { entry in
+                guard let name = entry["name"] as? String, let score = entry["score"] as? Double else { return nil }
+                return SeasonRankingEntry(name: name, score: score)
+            }
+
         return CollectedPerfume(
             id: document.documentID,
             name: name,
@@ -40,8 +46,15 @@ extension FirestoreService {
             imageUrl: data["imageUrl"] as? String ?? data["imageURL"] as? String,
             mainAccords: mainAccords,
             accordStrengths: accordStrengths,
-            memo: data["memo"] as? String,       // 신규
-            createdAt: timestamp?.dateValue()
+            memo: data["memo"] as? String,
+            createdAt: timestamp?.dateValue(),
+            topNotes: data["topNotes"] as? [String],
+            middleNotes: data["middleNotes"] as? [String],
+            baseNotes: data["baseNotes"] as? [String],
+            seasonRanking: seasonRanking,
+            concentration: data["concentration"] as? String,
+            longevity: data["longevity"] as? String,
+            sillage: data["sillage"] as? String
         )
     }
 

--- a/Sniff/Data/Remote/Firebase/FirestoreService.swift
+++ b/Sniff/Data/Remote/Firebase/FirestoreService.swift
@@ -203,6 +203,21 @@ final class FirestoreService {
         ]
 
         if let imageUrl = perfume.imageUrl { data["imageUrl"] = imageUrl }
+        if let topNotes = perfume.topNotes, !topNotes.isEmpty { data["topNotes"] = topNotes }
+        if let middleNotes = perfume.middleNotes, !middleNotes.isEmpty { data["middleNotes"] = middleNotes }
+        if let baseNotes = perfume.baseNotes, !baseNotes.isEmpty { data["baseNotes"] = baseNotes }
+        if !perfume.seasonRanking.isEmpty {
+            data["seasonRanking"] = perfume.seasonRanking.map { ["name": $0.name, "score": $0.score] }
+        }
+        if let concentration = perfume.concentration, !concentration.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            data["concentration"] = concentration
+        }
+        if let longevity = perfume.longevity, !longevity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            data["longevity"] = longevity
+        }
+        if let sillage = perfume.sillage, !sillage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            data["sillage"] = sillage
+        }
 
         try await ref.setData(data, merge: true)
     }
@@ -239,10 +254,24 @@ final class FirestoreService {
         ]
 
         if let imageUrl = perfume.imageUrl { data["imageUrl"] = imageUrl }
-        if let concentration = perfume.concentration { data["concentration"] = concentration }
+        if let concentration = perfume.concentration, !concentration.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            data["concentration"] = concentration
+        }
         if let gender = perfume.gender { data["gender"] = gender }
         if let memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             data["memo"] = memo
+        }
+        if let topNotes = perfume.topNotes, !topNotes.isEmpty { data["topNotes"] = topNotes }
+        if let middleNotes = perfume.middleNotes, !middleNotes.isEmpty { data["middleNotes"] = middleNotes }
+        if let baseNotes = perfume.baseNotes, !baseNotes.isEmpty { data["baseNotes"] = baseNotes }
+        if !perfume.seasonRanking.isEmpty {
+            data["seasonRanking"] = perfume.seasonRanking.map { ["name": $0.name, "score": $0.score] }
+        }
+        if let longevity = perfume.longevity, !longevity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            data["longevity"] = longevity
+        }
+        if let sillage = perfume.sillage, !sillage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            data["sillage"] = sillage
         }
 
         try await ref.setData(data, merge: true)
@@ -343,6 +372,12 @@ private extension FirestoreService {
         let mainAccords = ScentFamilyNormalizer.canonicalNames(
             for: rawMainAccords.isEmpty ? legacyAccords : rawMainAccords
         )
+        let seasonRanking: [SeasonRankingEntry] = (data["seasonRanking"] as? [[String: Any]] ?? [])
+            .compactMap { entry in
+                guard let name = entry["name"] as? String, let score = entry["score"] as? Double else { return nil }
+                return SeasonRankingEntry(name: name, score: score)
+            }
+
         return LikedPerfume(
             id: document.documentID,
             name: name,
@@ -351,7 +386,14 @@ private extension FirestoreService {
             scentFamily2: data["scentFamily2"] as? String,
             imageURL: data["imageUrl"] as? String ?? data["imageURL"] as? String,
             mainAccords: mainAccords,
-            likedAt: timestamp?.dateValue()
+            likedAt: timestamp?.dateValue(),
+            topNotes: data["topNotes"] as? [String],
+            middleNotes: data["middleNotes"] as? [String],
+            baseNotes: data["baseNotes"] as? [String],
+            seasonRanking: seasonRanking,
+            concentration: data["concentration"] as? String,
+            longevity: data["longevity"] as? String,
+            sillage: data["sillage"] as? String
         )
     }
 

--- a/Sniff/Data/Repository/CollectionRepository.swift
+++ b/Sniff/Data/Repository/CollectionRepository.swift
@@ -10,13 +10,24 @@ import RxSwift
 final class CollectionRepository: CollectionRepositoryType {
     private let firestoreService: FirestoreService
     private let cacheStore: CollectedPerfumeCacheStore
+    private let usageLimiter: CollectionUsageLimiter
 
     init(
         firestoreService: FirestoreService? = nil,
-        cacheStore: CollectedPerfumeCacheStore = CollectedPerfumeCacheStore()
+        cacheStore: CollectedPerfumeCacheStore = CollectedPerfumeCacheStore(),
+        usageLimiter: CollectionUsageLimiter = .shared
     ) {
         self.firestoreService = firestoreService ?? .shared
         self.cacheStore = cacheStore
+        self.usageLimiter = usageLimiter
+    }
+
+    var monthlyCollectionLimit: Int {
+        usageLimiter.monthlyCollectionLimit
+    }
+
+    func currentMonthlyCollectionUsage() -> Int {
+        usageLimiter.currentMonthlyCollectionUsage()
     }
 
     func fetchCollection() -> Single<[CollectedPerfume]> {
@@ -51,7 +62,9 @@ final class CollectionRepository: CollectionRepositoryType {
             }
             let task = Task {
                 do {
+                    try self.usageLimiter.validateCollectionChange()
                     try await self.firestoreService.saveCollectedPerfume(perfume, memo: memo)
+                    self.usageLimiter.recordCollectionChange()
                     self.cacheStore.upsert(
                         CollectedPerfume(
                             id: perfume.id,
@@ -118,7 +131,16 @@ final class CollectionRepository: CollectionRepositoryType {
             }
             let task = Task {
                 do {
+                    let likedPerfumes = try await self.firestoreService.fetchLikedPerfumes()
+                    if likedPerfumes.contains(where: { $0.id == perfume.id }) {
+                        try await self.firestoreService.saveLikedPerfume(perfume)
+                        completable(.completed)
+                        return
+                    }
+
+                    try self.usageLimiter.validateLikeAddition(currentTotalLikes: likedPerfumes.count)
                     try await self.firestoreService.saveLikedPerfume(perfume)
+                    self.usageLimiter.recordLikeAddition()
                     completable(.completed)
                 } catch {
                     completable(.error(error))

--- a/Sniff/Domain/Model/CollectedPerfume.swift
+++ b/Sniff/Domain/Model/CollectedPerfume.swift
@@ -16,6 +16,13 @@ struct CollectedPerfume {
     let accordStrengths: [String: AccordStrength]
     let memo: String?
     let createdAt: Date?
+    let topNotes: [String]?
+    let middleNotes: [String]?
+    let baseNotes: [String]?
+    let seasonRanking: [SeasonRankingEntry]
+    let concentration: String?
+    let longevity: String?
+    let sillage: String?
 
     var scentFamilies: [String] {
         mainAccords.filter { !$0.isEmpty }
@@ -94,6 +101,40 @@ extension CollectedPerfume {
 }
 
 extension CollectedPerfume {
+    nonisolated init(
+        id: String,
+        name: String,
+        brand: String,
+        imageUrl: String? = nil,
+        mainAccords: [String],
+        accordStrengths: [String: AccordStrength],
+        memo: String?,
+        createdAt: Date?,
+        topNotes: [String]? = nil,
+        middleNotes: [String]? = nil,
+        baseNotes: [String]? = nil,
+        seasonRanking: [SeasonRankingEntry] = [],
+        concentration: String? = nil,
+        longevity: String? = nil,
+        sillage: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.brand = brand
+        self.imageUrl = imageUrl
+        self.mainAccords = mainAccords
+        self.accordStrengths = accordStrengths
+        self.memo = memo
+        self.createdAt = createdAt
+        self.topNotes = topNotes
+        self.middleNotes = middleNotes
+        self.baseNotes = baseNotes
+        self.seasonRanking = seasonRanking
+        self.concentration = concentration
+        self.longevity = longevity
+        self.sillage = sillage
+    }
+
     nonisolated func toPerfume() -> Perfume {
         Perfume(
             id: id,
@@ -103,16 +144,16 @@ extension CollectedPerfume {
             rawMainAccords: mainAccords,
             mainAccords: mainAccords,
             mainAccordStrengths: accordStrengths,
-            topNotes: nil,
-            middleNotes: nil,
-            baseNotes: nil,
-            concentration: nil,
+            topNotes: topNotes,
+            middleNotes: middleNotes,
+            baseNotes: baseNotes,
+            concentration: concentration,
             gender: nil,
             season: nil,
-            seasonRanking: [],
+            seasonRanking: seasonRanking,
             situation: nil,
-            longevity: nil,
-            sillage: nil
+            longevity: longevity,
+            sillage: sillage
         )
     }
 }

--- a/Sniff/Domain/Model/LikedPerfume.swift
+++ b/Sniff/Domain/Model/LikedPerfume.swift
@@ -17,6 +17,13 @@ struct LikedPerfume: Identifiable {
     let imageURL: String?
     let mainAccords: [String]
     let likedAt: Date?
+    let topNotes: [String]?
+    let middleNotes: [String]?
+    let baseNotes: [String]?
+    let seasonRanking: [SeasonRankingEntry]
+    let concentration: String?
+    let longevity: String?
+    let sillage: String?
 
     /// 화면 표시용 향 계열 배열 (nil 제거)
     var scentFamilies: [String] {
@@ -34,16 +41,16 @@ extension LikedPerfume {
             rawMainAccords: mainAccords,
             mainAccords: mainAccords,
             mainAccordStrengths: [:],
-            topNotes: nil,
-            middleNotes: nil,
-            baseNotes: nil,
-            concentration: nil,
+            topNotes: topNotes,
+            middleNotes: middleNotes,
+            baseNotes: baseNotes,
+            concentration: concentration,
             gender: nil,
             season: nil,
-            seasonRanking: [],
+            seasonRanking: seasonRanking,
             situation: nil,
-            longevity: nil,
-            sillage: nil
+            longevity: longevity,
+            sillage: sillage
         )
     }
 }

--- a/Sniff/Domain/Repository/CollectionRepositoryType.swift
+++ b/Sniff/Domain/Repository/CollectionRepositoryType.swift
@@ -10,6 +10,8 @@ import RxSwift
 
 protocol CollectionRepositoryType {
     func fetchCollection() -> Single<[CollectedPerfume]>
+    func currentMonthlyCollectionUsage() -> Int
+    var monthlyCollectionLimit: Int { get }
     func saveCollectedPerfume(_ perfume: Perfume, memo: String?) -> Completable
     func deleteCollectedPerfume(id: String) -> Completable
     func fetchLikedPerfumes() -> Single<[LikedPerfume]>

--- a/Sniff/Localization/UIStrings/AppStrings+Collection.swift
+++ b/Sniff/Localization/UIStrings/AppStrings+Collection.swift
@@ -16,4 +16,14 @@ extension AppStrings {
         static let removeButton = "제거할게요"
         static let cancelButton = "아니요, 유지할게요"
     }
+
+    enum CollectionUsageLimits {
+        static let monthlyCollectionLimitReached = "이번 달 5개 한도를 채웠어요. 다음 달에 추가할 수 있어요"
+        static let dailyLikeLimitReached = "오늘 10개 한도를 채웠어요"
+        static let totalLikeLimitReached = "최대 100개까지 저장할 수 있어요"
+
+        static func monthlyUsage(_ count: Int, limit: Int) -> String {
+            "이번 달 \(count)/\(limit)"
+        }
+    }
 }

--- a/Sniff/Presentation/common/Components/UIViewController+Toast.swift
+++ b/Sniff/Presentation/common/Components/UIViewController+Toast.swift
@@ -1,0 +1,51 @@
+//
+//  UIViewController+Toast.swift
+//  Sniff
+//
+
+import UIKit
+import SnapKit
+
+extension UIViewController {
+    func showAppToast(message: String, bottomOffset: CGFloat = 36) {
+        view.subviews
+            .filter { $0.accessibilityIdentifier == "appToastView" }
+            .forEach { $0.removeFromSuperview() }
+
+        let container = UIView()
+        container.accessibilityIdentifier = "appToastView"
+        container.backgroundColor = UIColor.black.withAlphaComponent(0.86)
+        container.layer.cornerRadius = 12
+        container.layer.masksToBounds = true
+
+        let label = UILabel()
+        label.text = message
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.textAlignment = .center
+        label.numberOfLines = 2
+
+        container.addSubview(label)
+        view.addSubview(container)
+
+        label.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 13, left: 18, bottom: 13, right: 18))
+        }
+
+        container.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-bottomOffset)
+        }
+
+        container.alpha = 0
+        UIView.animate(withDuration: 0.2) {
+            container.alpha = 1
+        } completion: { _ in
+            UIView.animate(withDuration: 0.2, delay: 2.8, options: [.curveEaseInOut]) {
+                container.alpha = 0
+            } completion: { [weak container] _ in
+                container?.removeFromSuperview()
+            }
+        }
+    }
+}

--- a/Sniff/Presentation/common/Tab/Home/ViewControllers/HomeViewController.swift
+++ b/Sniff/Presentation/common/Tab/Home/ViewControllers/HomeViewController.swift
@@ -510,6 +510,8 @@ private extension HomeViewController {
             .subscribe(onCompleted: { [weak self] in
                 self?.likedPerfumeIDs.insert(item.id)
                 self?.recommendationCollectionView.reloadData()
+            }, onError: { [weak self] error in
+                self?.presentLikeMutationError(error)
             })
             .disposed(by: disposeBag)
     }
@@ -520,8 +522,18 @@ private extension HomeViewController {
             .subscribe(onCompleted: { [weak self] in
                 self?.likedPerfumeIDs.remove(id)
                 self?.recommendationCollectionView.reloadData()
+            }, onError: { [weak self] error in
+                self?.presentLikeMutationError(error)
             })
             .disposed(by: disposeBag)
+    }
+
+    func presentLikeMutationError(_ error: Error) {
+        if let limitError = error as? CollectionUsageLimitError {
+            showAppToast(message: limitError.localizedDescription, bottomOffset: 84)
+        } else {
+            presentAlert(error.localizedDescription)
+        }
     }
 
     var visibleRecommendations: [HomePerfumeItem] {

--- a/Sniff/Presentation/common/Tab/Home/ViewModels/HomeViewModel.swift
+++ b/Sniff/Presentation/common/Tab/Home/ViewModels/HomeViewModel.swift
@@ -44,6 +44,9 @@ final class HomeViewModel {
     private let routeRelay = PublishRelay<HomeRoute>()
     private let recommendationItemsRelay = BehaviorRelay<[HomePerfumeItem]>(value: [])
 
+    private var cachedFeedData: HomeFeedData?
+    private let updateTracker = RecommendationUpdateTracker()
+
     private let userTasteRepository: UserTasteRepositoryType
     private let collectionRepository: CollectionRepositoryType
     private let tastingRecordRepository: TastingRecordRepositoryType
@@ -76,7 +79,7 @@ final class HomeViewModel {
         let sourceData = input.viewDidLoad
             .flatMapLatest { [weak self] _ -> Observable<HomeFeedData?> in
                 guard let self else { return .just(nil) }
-                return self.fetchHomeFeed()
+                return self.fetchHomeFeedIfNeeded()
                     .map(Optional.some)
                     .catchAndReturn(nil)
                     .asObservable()
@@ -178,6 +181,25 @@ final class HomeViewModel {
 }
 
 private extension HomeViewModel {
+
+    func fetchHomeFeedIfNeeded() -> Single<HomeFeedData> {
+        // 당일 한도(2회) 소진 + 캐시 있음 → Firestore 재조회 없이 캐시 반환
+        if updateTracker.todayUpdateCount >= 2, let cached = cachedFeedData {
+            return .just(cached)
+        }
+
+        return fetchHomeFeed()
+            .do(onSuccess: { [weak self] data in
+                guard let self else { return }
+                self.cachedFeedData = data
+                if self.updateTracker.canRecord(
+                    collectionCount: data.collection.count,
+                    tastingCount: data.tastingRecords.count
+                ) {
+                    self.updateTracker.recordUpdate()
+                }
+            })
+    }
 
     func fetchHomeFeed() -> Single<HomeFeedData> {
         Single.zip(

--- a/Sniff/Presentation/common/Tab/MyPage/ViewModels/MyPageViewModel.swift
+++ b/Sniff/Presentation/common/Tab/MyPage/ViewModels/MyPageViewModel.swift
@@ -46,6 +46,7 @@ final class MyPageViewModel: ObservableObject {
     @Published private(set) var likedCount: Int = 0
     @Published private(set) var isLoading = false
     @Published var errorMessage: String?
+    @Published var toastMessage: String?
 
     private enum DisplayLimit {
         static let ownedPreview = 5
@@ -61,6 +62,7 @@ final class MyPageViewModel: ObservableObject {
     private let localTastingNoteRepository: LocalTastingNoteRepository
     private var allOwnedPerfumes: [OwnedPreviewItem] = []
     private var allLikedPerfumes: [LikedPreviewItem] = []
+    private var toastTask: Task<Void, Never>?
 
     init(
         firestoreService: FirestoreService,
@@ -72,6 +74,10 @@ final class MyPageViewModel: ObservableObject {
         self.collectionRepository = collectionRepository
         self.tastingRepository = tastingRepository
         self.localTastingNoteRepository = localTastingNoteRepository
+    }
+
+    deinit {
+        toastTask?.cancel()
     }
 
     func load() async {
@@ -240,7 +246,7 @@ final class MyPageViewModel: ObservableObject {
             allLikedPerfumes = previousLiked
             likedCount = previousLikedCount
             applyPreviewLimits()
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -274,7 +280,7 @@ final class MyPageViewModel: ObservableObject {
             likedCount = previousLikedCount
             allOwnedPerfumes = previousOwned
             applyPreviewLimits()
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 }
@@ -533,6 +539,24 @@ private extension MyPageViewModel {
     func applyPreviewLimits() {
         ownedPerfumes = Array(allOwnedPerfumes.prefix(DisplayLimit.ownedPreview))
         likedPerfumes = Array(allLikedPerfumes.prefix(DisplayLimit.likedPreview))
+    }
+
+    func handleError(_ error: Error) {
+        if let limitError = error as? CollectionUsageLimitError {
+            showToast(message: limitError.localizedDescription)
+        } else {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func showToast(message: String) {
+        toastMessage = message
+        toastTask?.cancel()
+        toastTask = Task {
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            toastMessage = nil
+        }
     }
 }
 

--- a/Sniff/Presentation/common/Tab/MyPage/Views/MyPageView.swift
+++ b/Sniff/Presentation/common/Tab/MyPage/Views/MyPageView.swift
@@ -40,16 +40,25 @@ struct MyPageView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-                    headerSection
-                    profileSection
-                    ownedSection
-                    likedSection
+            ZStack(alignment: .bottom) {
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                        headerSection
+                        profileSection
+                        ownedSection
+                        likedSection
+                    }
+                    .padding(.horizontal, Layout.horizontalPadding)
+                    .padding(.top, Layout.headerTopPadding)
+                    .padding(.bottom, Layout.bottomContentPadding)
                 }
-                .padding(.horizontal, Layout.horizontalPadding)
-                .padding(.top, Layout.headerTopPadding)
-                .padding(.bottom, Layout.bottomContentPadding)
+
+                if let message = viewModel.toastMessage {
+                    toastView(message)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 28)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
             .background(Color(.systemBackground))
             .toolbar(.hidden, for: .navigationBar)
@@ -72,6 +81,7 @@ struct MyPageView: View {
             } message: {
                 Text(viewModel.errorMessage ?? "")
             }
+            .animation(.easeInOut(duration: 0.2), value: viewModel.toastMessage)
         }
     }
 
@@ -215,6 +225,17 @@ struct MyPageView: View {
             .buttonStyle(.plain)
         }
         .padding(.bottom, Layout.sectionHeaderBottomSpacing)
+    }
+
+    private func toastView(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: 15, weight: .medium))
+            .foregroundColor(.white)
+            .padding(.horizontal, 20)
+            .frame(maxWidth: .infinity)
+            .frame(height: 52)
+            .background(Color.black.opacity(0.85))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
     private func emptySection(title: String, message: String) -> some View {

--- a/Sniff/Presentation/common/Tab/PerfumeDetail/ViewControllers/PerfumeDetailView.swift
+++ b/Sniff/Presentation/common/Tab/PerfumeDetail/ViewControllers/PerfumeDetailView.swift
@@ -517,7 +517,7 @@ final class PerfumeDetailViewController: UIViewController {
         UIView.animate(withDuration: 0.2) {
             container.alpha = 1
         } completion: { _ in
-            UIView.animate(withDuration: 0.2, delay: 1.8, options: [.curveEaseInOut]) {
+            UIView.animate(withDuration: 0.2, delay: 2.8, options: [.curveEaseInOut]) {
                 container.alpha = 0
             } completion: { [weak container] _ in
                 container?.removeFromSuperview()
@@ -596,7 +596,7 @@ final class PerfumeDetailViewController: UIViewController {
                 }, onError: { [weak self] error in
                     self?.likeButton.isEnabled = true
                     self?.updateLikeState(for: perfume.id, isLiked: wasLiked)
-                    self?.showErrorAlert(message: error.localizedDescription)
+                    self?.presentMutationError(error)
                 })
                 .disposed(by: disposeBag)
         }
@@ -626,7 +626,7 @@ final class PerfumeDetailViewController: UIViewController {
                 }, onError: { [weak self] error in
                     self?.addCollectionButton.isEnabled = true
                     self?.updateOwnedState(for: perfume.id, isOwned: wasOwned)
-                    self?.showErrorAlert(message: error.localizedDescription)
+                    self?.presentMutationError(error)
                 })
                 .disposed(by: disposeBag)
         } else {
@@ -637,7 +637,7 @@ final class PerfumeDetailViewController: UIViewController {
                 }, onError: { [weak self] error in
                     self?.addCollectionButton.isEnabled = true
                     self?.updateOwnedState(for: perfume.id, isOwned: wasOwned)
-                    self?.showErrorAlert(message: error.localizedDescription)
+                    self?.presentMutationError(error)
                 })
                 .disposed(by: disposeBag)
         }
@@ -686,5 +686,13 @@ final class PerfumeDetailViewController: UIViewController {
     private func updateTastingButtonUI() {
         let title = hasTastingRecord ? "시향기로 이동" : AppStrings.UIKitScreens.PerfumeDetail.addTasting
         addTastingButton.setTitle(title, for: .normal)
+    }
+
+    private func presentMutationError(_ error: Error) {
+        if let limitError = error as? CollectionUsageLimitError {
+            showToast(message: limitError.localizedDescription)
+        } else {
+            showErrorAlert(message: error.localizedDescription)
+        }
     }
 }

--- a/Sniff/Presentation/common/Tab/Search/ViewControllers/SearchViewController.swift
+++ b/Sniff/Presentation/common/Tab/Search/ViewControllers/SearchViewController.swift
@@ -803,8 +803,8 @@ private extension SearchViewController {
             .subscribe(onCompleted: { [weak self] in
                 self?.likedPerfumeIDs.insert(perfume.id)
                 self?.reloadPerfumeResults()
-            }, onError: { [weak self] _ in
-                self?.presentSaveFailureAlert()
+            }, onError: { [weak self] error in
+                self?.presentSaveFailure(error)
             })
             .disposed(by: disposeBag)
     }
@@ -817,13 +817,18 @@ private extension SearchViewController {
             .subscribe(onCompleted: { [weak self] in
                 self?.likedPerfumeIDs.remove(id)
                 self?.reloadPerfumeResults()
-            }, onError: { [weak self] _ in
-                self?.presentSaveFailureAlert()
+            }, onError: { [weak self] error in
+                self?.presentSaveFailure(error)
             })
             .disposed(by: disposeBag)
     }
 
-    private func presentSaveFailureAlert() {
+    private func presentSaveFailure(_ error: Error) {
+        if let limitError = error as? CollectionUsageLimitError {
+            showAppToast(message: limitError.localizedDescription)
+            return
+        }
+
         let alert = UIAlertController(title: nil, message: AppStrings.UIKitScreens.Search.likeSaveFailed, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: AppStrings.UIKitScreens.confirm, style: .default))
         present(alert, animated: true)

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/LikedPerfumeListViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/LikedPerfumeListViewModel.swift
@@ -97,16 +97,16 @@ final class LikedPerfumeListViewModel: ObservableObject {
                     rawMainAccords: liked.mainAccords,
                     mainAccords: liked.mainAccords,
                     mainAccordStrengths: [:],
-                    topNotes: nil,
-                    middleNotes: nil,
-                    baseNotes: nil,
-                    concentration: nil,
+                    topNotes: liked.topNotes,
+                    middleNotes: liked.middleNotes,
+                    baseNotes: liked.baseNotes,
+                    concentration: liked.concentration,
                     gender: nil,
                     season: nil,
-                    seasonRanking: [],
+                    seasonRanking: liked.seasonRanking,
                     situation: nil,
-                    longevity: nil,
-                    sillage: nil
+                    longevity: liked.longevity,
+                    sillage: liked.sillage
                 )
 
                 return PerfumeRowItem(

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/OwnedPerfumeListViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/OwnedPerfumeListViewModel.swift
@@ -32,10 +32,12 @@ final class OwnedPerfumeListViewModel: ObservableObject {
     @Published var isEditMode = false
     @Published private(set) var selectedPerfumeIDs = Set<String>()
     @Published var toastMessage: String?
+    @Published private(set) var monthlyUsageCount: Int = 0
 
     var isEmpty: Bool { perfumes.isEmpty }
     var perfumeCount: Int { perfumes.count }
     var hasSelection: Bool { !selectedPerfumeIDs.isEmpty }
+    var monthlyUsageLimit: Int { collectionRepository.monthlyCollectionLimit }
 
     private let collectionRepository: CollectionRepositoryType
     private let tastingRepository: TastingRecordRepositoryType
@@ -61,6 +63,7 @@ final class OwnedPerfumeListViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
+            monthlyUsageCount = collectionRepository.currentMonthlyCollectionUsage()
             let collection = try await fetchCollection()
 
             let tastingKeys = await fetchTastingKeys()
@@ -101,7 +104,7 @@ final class OwnedPerfumeListViewModel: ObservableObject {
 
             selectedPerfumeIDs = selectedPerfumeIDs.intersection(Set(perfumes.map(\.id)))
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -136,7 +139,7 @@ final class OwnedPerfumeListViewModel: ObservableObject {
             await load()
             showToast(message: AppStrings.ViewModelMessages.TastingNote.deletedOwnedCount(deletedCount))
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -170,7 +173,7 @@ final class OwnedPerfumeListViewModel: ObservableObject {
             }
         } catch {
             perfumes = previousPerfumes
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 }
@@ -219,9 +222,17 @@ private extension OwnedPerfumeListViewModel {
         toastMessage = message
         toastTask?.cancel()
         toastTask = Task {
-            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
             guard !Task.isCancelled else { return }
             toastMessage = nil
+        }
+    }
+
+    func handleError(_ error: Error) {
+        if let limitError = error as? CollectionUsageLimitError {
+            showToast(message: limitError.localizedDescription)
+        } else {
+            errorMessage = error.localizedDescription
         }
     }
 }

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
@@ -8,7 +8,6 @@
 // MARK: - 등록 로직
 import Foundation
 import FirebaseAuth
-import FirebaseFirestore
 import Combine
 
 @MainActor
@@ -55,15 +54,6 @@ final class TastingNoteFormViewModel: ObservableObject {
     // MARK: - Private
 
     private var perfumeImageURL: String?
-
-    private var uid: String? { Auth.auth().currentUser?.uid }
-
-    private var collectionRef: CollectionReference? {
-        guard let uid else { return nil }
-        return Firestore.firestore()
-            .collection("users").document(uid)
-            .collection("tastingRecords")
-    }
 
     // MARK: - Init
 
@@ -187,38 +177,4 @@ final class TastingNoteFormViewModel: ObservableObject {
         }
     }
 
-    private func findDuplicateNote(in ref: CollectionReference) async throws -> TastingNoteDocument? {
-        let snapshot = try await ref.getDocuments()
-        let currentKey = duplicateKey(perfumeName: perfumeName, brandName: brandName)
-
-        let matches: [TastingNoteDocument] = snapshot.documents.compactMap { document -> TastingNoteDocument? in
-            guard var note = try? document.data(as: TastingNote.self),
-                  duplicateKey(perfumeName: note.perfumeName, brandName: note.brandName) == currentKey else {
-                return nil
-            }
-            note.id = document.documentID
-            return TastingNoteDocument(id: document.documentID, note: note)
-        }
-
-        return matches
-            .sorted { lhs, rhs in lhs.note.createdAt > rhs.note.createdAt }
-            .first
-    }
-
-    private func duplicateKey(perfumeName: String, brandName: String) -> String {
-        let normalizedName = perfumeName
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        let normalizedBrand = brandName
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        return "\(normalizedBrand)|\(normalizedName)"
-    }
-}
-
-private struct TastingNoteDocument {
-    let id: String
-    let note: TastingNote
-
-    var createdAt: Date { note.createdAt }
 }

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteViewModel.swift
@@ -77,7 +77,7 @@ final class TastingNoteViewModel: ObservableObject {
             filtered = scopedNotes.filter { !noteKeys($0).isDisjoint(with: likedKeys) }
         }
 
-        return uniqueLatestNotes(from: filtered)
+        return filtered
     }
 
     /// 전체 목록이 비어있는지 (삭제 버튼 활성화 기준)
@@ -279,14 +279,6 @@ final class TastingNoteViewModel: ObservableObject {
 
     private func noteKeys(_ note: TastingNote) -> Set<String> {
         perfumeKeys(perfumeName: note.perfumeName, brandName: note.brandName)
-    }
-
-    private func uniqueLatestNotes(from notes: [TastingNote]) -> [TastingNote] {
-        var seenKeys = Set<String>()
-        return notes.filter { note in
-            let key = primaryPerfumeKey(perfumeName: note.perfumeName, brandName: note.brandName)
-            return seenKeys.insert(key).inserted
-        }
     }
 
     private func perfumeKeys(perfumeName: String, brandName: String) -> Set<String> {

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/OwnedPerfumeListView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/OwnedPerfumeListView.swift
@@ -10,6 +10,7 @@ struct OwnedPerfumeListView: View {
 
     @StateObject private var viewModel: OwnedPerfumeListViewModel
     @Environment(\.dismiss) private var dismiss
+    @State private var showsMonthlyUsageInfo = false
     private enum Layout {
         static let horizontalPadding: CGFloat = PerfumeGridCardLayout.gridHorizontalPadding
         static let columnSpacing: CGFloat = PerfumeGridCardLayout.gridColumnSpacing
@@ -95,6 +96,37 @@ struct OwnedPerfumeListView: View {
                     Text(AppStrings.TastingNoteUI.OwnedList.count(viewModel.perfumeCount))
                         .font(.system(size: 22, weight: .medium))
                         .foregroundColor(Color(.systemGray2))
+
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.22)) {
+                            showsMonthlyUsageInfo.toggle()
+                        }
+                    } label: {
+                        ZStack {
+                            if showsMonthlyUsageInfo {
+                                Text(AppStrings.CollectionUsageLimits.monthlyUsage(
+                                    viewModel.monthlyUsageCount,
+                                    limit: viewModel.monthlyUsageLimit
+                                ))
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(Color(.systemGray))
+                                .padding(.horizontal, 9)
+                                .frame(height: 26)
+                                .background(Color(.systemGray6))
+                                .clipShape(Capsule())
+                                .transition(.move(edge: .trailing).combined(with: .opacity))
+                            } else {
+                                Text("!")
+                                    .font(.system(size: 13, weight: .bold))
+                                    .foregroundColor(Color(.systemGray))
+                                    .frame(width: 22, height: 22)
+                                    .background(Color(.systemGray6))
+                                    .clipShape(Circle())
+                                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
                 }
             }
 


### PR DESCRIPTION
## Summary
- 보유 향수 추가/변경을 월 5회로 제한 (CollectionUsageLimiter.swift 신규 추가)
- LIKE 향수 전체 100개, 하루 신규 LIKE 10개 제한
- 보유 향수 및 LIKE 삭제는 제한 없이 동작
- 제한 도달 시 토스트 메시지 3초 후 자동 사라짐
- 보유 향수 목록 `보유 향수 n개` 옆 `!` 버튼 추가, 탭 시 `이번 달 n/5` 슬라이드 표시

## Changes
- `CollectionUsageLimiter.swift` 신규 추가
- 보유 향수, Like 향수 등록 제한 로직 반영
- 토스트 메시지 처리 (Detail, Search, Home, OwnedList, MyPage)
- ! 버튼 UI 추가