### PR TITLE
refactor: 시향기 UI 및 기능 수정 및 회원 탈퇴 로직 수정

### DIFF
--- a/Sniff/App/DI/SettingsSceneFactory.swift
+++ b/Sniff/App/DI/SettingsSceneFactory.swift
@@ -24,6 +24,11 @@ enum SettingsSceneFactory {
 
     @MainActor
     static func makeWithdrawView(nickname: String) -> WithdrawView {
-        WithdrawView(nickname: nickname)
+        let container = AppDependencyContainer.shared
+        let viewModel = WithdrawViewModel(
+            nickname: nickname,
+            authService: container.authService
+        )
+        return WithdrawView(viewModel: viewModel)
     }
 }

--- a/Sniff/Data/Local/CoreDataStack.swift
+++ b/Sniff/Data/Local/CoreDataStack.swift
@@ -40,4 +40,20 @@ final class CoreDataStack {
         guard viewContext.hasChanges else { return }
         try viewContext.save()
     }
+
+    /// 로컬 Core Data에 저장된 모든 시향기 데이터를 삭제합니다.
+    /// 회원 탈퇴 시 기기에 남은 개인 데이터를 완전히 지우기 위해 호출합니다.
+    func deleteAllTastingNotes() throws {
+        let request: NSFetchRequest<NSFetchRequestResult> = LocalTastingNoteEntity.fetchRequest()
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        deleteRequest.resultType = .resultTypeObjectIDs
+
+        let result = try viewContext.execute(deleteRequest) as? NSBatchDeleteResult
+        let objectIDs = result?.result as? [NSManagedObjectID] ?? []
+
+        NSManagedObjectContext.mergeChanges(
+            fromRemoteContextSave: [NSDeletedObjectsKey: objectIDs],
+            into: [viewContext]
+        )
+    }
 }

--- a/Sniff/Data/Local/LocalTastingNoteRepository.swift
+++ b/Sniff/Data/Local/LocalTastingNoteRepository.swift
@@ -31,6 +31,8 @@ final class LocalTastingNoteRepository {
     private let coreDataStack: CoreDataStack
     private let database: Firestore
     private let userTasteRepository: UserTasteRepositoryType
+    /// Gemini 취향 재분석 호출 횟수를 하루 2회로 제한합니다.
+    private let recommendationTracker = RecommendationUpdateTracker()
 
     private var context: NSManagedObjectContext {
         coreDataStack.viewContext
@@ -237,7 +239,17 @@ final class LocalTastingNoteRepository {
     private func refreshNarrativeIfNeeded() async {
         guard let records = try? await FirestoreService.shared.fetchTastingRecords() else { return }
         guard shouldRefreshNarrative(with: records) else { return }
-        _ = try? await userTasteRepository.reanalyzeTasteFromHistory()
+
+        // 하루 최대 2회까지만 Gemini 취향 재분석을 호출합니다.
+        // 시향 기록을 자주 수정하더라도 불필요한 API 비용이 발생하지 않습니다.
+        guard recommendationTracker.canRecord(
+            collectionCount: 0,
+            tastingCount: records.count
+        ) else { return }
+
+        if (try? await userTasteRepository.reanalyzeTasteFromHistory()) != nil {
+            recommendationTracker.recordUpdate()
+        }
     }
 
     private func shouldRefreshNarrative(with records: [TastingRecord]) -> Bool {

--- a/Sniff/Data/Remote/Firebase/AuthService.swift
+++ b/Sniff/Data/Remote/Firebase/AuthService.swift
@@ -11,6 +11,7 @@ import FirebaseAuth
 enum AuthServiceError: LocalizedError {
     case missingIdentityToken
     case invalidIdentityToken
+    case missingCurrentUser
 
     var errorDescription: String? {
         switch self {
@@ -18,6 +19,8 @@ enum AuthServiceError: LocalizedError {
             return "Apple 로그인 토큰을 받지 못했어요"
         case .invalidIdentityToken:
             return "Apple 로그인 토큰을 해석하지 못했어요"
+        case .missingCurrentUser:
+            return "로그인된 사용자 정보를 찾을 수 없어요"
         }
     }
 }
@@ -32,20 +35,7 @@ final class AuthService: AuthServiceType {
         identityToken: Data?,
         rawNonce: String
     ) async throws -> AuthSession {
-        guard let identityToken else {
-            throw AuthServiceError.missingIdentityToken
-        }
-
-        guard let idTokenString = String(data: identityToken, encoding: .utf8) else {
-            throw AuthServiceError.invalidIdentityToken
-        }
-
-        let credential = OAuthProvider.appleCredential(
-            withIDToken: idTokenString,
-            rawNonce: rawNonce,
-            fullName: nil
-        )
-
+        let credential = try makeAppleCredential(identityToken: identityToken, rawNonce: rawNonce)
         let result = try await Auth.auth().signIn(with: credential)
         return AuthSession(
             userID: result.user.uid,
@@ -53,7 +43,39 @@ final class AuthService: AuthServiceType {
         )
     }
 
+    /// Apple 자격증명으로 현재 사용자를 재인증합니다.
+    /// requiresRecentLogin(17014) 에러 발생 후 계정 삭제를 재시도하기 위해 호출합니다.
+    func reauthenticateWithApple(
+        identityToken: Data?,
+        rawNonce: String
+    ) async throws {
+        guard let currentUser = Auth.auth().currentUser else {
+            throw AuthServiceError.missingCurrentUser
+        }
+        let credential = try makeAppleCredential(identityToken: identityToken, rawNonce: rawNonce)
+        try await currentUser.reauthenticate(with: credential)
+    }
+
     func signOut() throws {
         try Auth.auth().signOut()
+    }
+
+    // MARK: - Private
+
+    private func makeAppleCredential(
+        identityToken: Data?,
+        rawNonce: String
+    ) throws -> OAuthCredential {
+        guard let identityToken else {
+            throw AuthServiceError.missingIdentityToken
+        }
+        guard let idTokenString = String(data: identityToken, encoding: .utf8) else {
+            throw AuthServiceError.invalidIdentityToken
+        }
+        return OAuthProvider.appleCredential(
+            withIDToken: idTokenString,
+            rawNonce: rawNonce,
+            fullName: nil
+        )
     }
 }

--- a/Sniff/Domain/Model/CollectedPerfume.swift
+++ b/Sniff/Domain/Model/CollectedPerfume.swift
@@ -24,6 +24,40 @@ struct CollectedPerfume {
     let longevity: String?
     let sillage: String?
 
+    nonisolated init(
+        id: String,
+        name: String,
+        brand: String,
+        imageUrl: String? = nil,
+        mainAccords: [String],
+        accordStrengths: [String: AccordStrength],
+        memo: String?,
+        createdAt: Date?,
+        topNotes: [String]? = nil,
+        middleNotes: [String]? = nil,
+        baseNotes: [String]? = nil,
+        seasonRanking: [SeasonRankingEntry] = [],
+        concentration: String? = nil,
+        longevity: String? = nil,
+        sillage: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.brand = brand
+        self.imageUrl = imageUrl
+        self.mainAccords = mainAccords
+        self.accordStrengths = accordStrengths
+        self.memo = memo
+        self.createdAt = createdAt
+        self.topNotes = topNotes
+        self.middleNotes = middleNotes
+        self.baseNotes = baseNotes
+        self.seasonRanking = seasonRanking
+        self.concentration = concentration
+        self.longevity = longevity
+        self.sillage = sillage
+    }
+
     var scentFamilies: [String] {
         mainAccords.filter { !$0.isEmpty }
     }
@@ -101,40 +135,6 @@ extension CollectedPerfume {
 }
 
 extension CollectedPerfume {
-    nonisolated init(
-        id: String,
-        name: String,
-        brand: String,
-        imageUrl: String? = nil,
-        mainAccords: [String],
-        accordStrengths: [String: AccordStrength],
-        memo: String?,
-        createdAt: Date?,
-        topNotes: [String]? = nil,
-        middleNotes: [String]? = nil,
-        baseNotes: [String]? = nil,
-        seasonRanking: [SeasonRankingEntry] = [],
-        concentration: String? = nil,
-        longevity: String? = nil,
-        sillage: String? = nil
-    ) {
-        self.id = id
-        self.name = name
-        self.brand = brand
-        self.imageUrl = imageUrl
-        self.mainAccords = mainAccords
-        self.accordStrengths = accordStrengths
-        self.memo = memo
-        self.createdAt = createdAt
-        self.topNotes = topNotes
-        self.middleNotes = middleNotes
-        self.baseNotes = baseNotes
-        self.seasonRanking = seasonRanking
-        self.concentration = concentration
-        self.longevity = longevity
-        self.sillage = sillage
-    }
-
     nonisolated func toPerfume() -> Perfume {
         Perfume(
             id: id,

--- a/Sniff/Domain/Repository/AuthServiceType.swift
+++ b/Sniff/Domain/Repository/AuthServiceType.swift
@@ -14,5 +14,8 @@ struct AuthSession {
 
 protocol AuthServiceType {
     func signInWithApple(identityToken: Data?, rawNonce: String) async throws -> AuthSession
+    /// Apple 자격증명으로 현재 사용자를 재인증합니다.
+    /// 계정 삭제 등 민감한 작업 전 requiresRecentLogin(17014) 에러 발생 시 호출합니다.
+    func reauthenticateWithApple(identityToken: Data?, rawNonce: String) async throws
     func signOut() throws
 }

--- a/Sniff/Info.plist
+++ b/Sniff/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>FRAGELLA_API_KEY</key>

--- a/Sniff/Presentation/common/Tab/Login/ViewModels/LoginViewModel.swift
+++ b/Sniff/Presentation/common/Tab/Login/ViewModels/LoginViewModel.swift
@@ -62,8 +62,10 @@ final class LoginViewModel: ObservableObject {
                 rawNonce: payload.rawNonce
             )
             isLoading = false
+            // Firestore 프로필 존재 여부만으로 신규/기존 유저 판단
+            // isNewUser는 Firebase Auth 계정 기준이므로, 탈퇴 후 재가입 시 오판할 수 있음
             let hasProfile = try await userProfileStatusRepository.hasUserProfile(userID: session.userID)
-            if hasProfile || !session.isNewUser {
+            if hasProfile {
                 onExistingUser()
             } else {
                 onNewUser()

--- a/Sniff/Presentation/common/Tab/Login/Views/LoginView.swift
+++ b/Sniff/Presentation/common/Tab/Login/Views/LoginView.swift
@@ -37,9 +37,15 @@ struct LoginView: View {
                 
                 // 커스텀 Apple 로그인 버튼
                 Button {
-                    guard let windowScene = UIApplication.shared.connectedScenes
-                        .first as? UIWindowScene,
-                          let window = windowScene.windows.first else { return }
+                    // isKeyWindow 기준으로 키 윈도우를 탐색합니다.
+                    // windows.first는 키 윈도우를 보장하지 않으므로 사용하지 않습니다.
+                    let scenes = UIApplication.shared.connectedScenes
+                        .compactMap { $0 as? UIWindowScene }
+                    guard let window = scenes
+                        .flatMap(\.windows)
+                        .first(where: \.isKeyWindow)
+                        ?? scenes.flatMap(\.windows).first
+                    else { return }
                     viewModel.signInWithApple(presentationAnchor: window)
                 } label: {
                     HStack(spacing: 8) {

--- a/Sniff/Presentation/common/Tab/Settings/ViewModels/WithdrawViewModel.swift
+++ b/Sniff/Presentation/common/Tab/Settings/ViewModels/WithdrawViewModel.swift
@@ -3,10 +3,10 @@
 //  Sniff
 //
 
-import Foundation
 import Combine
 import FirebaseAuth
 import FirebaseFirestore
+import Foundation
 
 // MARK: - 회원탈퇴 뷰모델
 
@@ -21,11 +21,20 @@ final class WithdrawViewModel: ObservableObject {
     /// 닉네임 (화면 상단 표시용)
     let nickname: String
 
-    init(nickname: String) {
+    private let authService: AuthServiceType
+    private let coreDataStack: CoreDataStack
+
+    nonisolated init(
+        nickname: String,
+        authService: AuthServiceType = AuthService.shared,
+        coreDataStack: CoreDataStack = .shared
+    ) {
         self.nickname = nickname
+        self.authService = authService
+        self.coreDataStack = coreDataStack
     }
 
-    // MARK: - 회원탈퇴 실행: Firestore 삭제 → Auth 삭제
+    // MARK: - 회원탈퇴 실행: Firestore 삭제 → 로컬 삭제 → 로그아웃
 
     func withdrawAccount() async {
         guard isAgreed else { return }
@@ -34,23 +43,21 @@ final class WithdrawViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
-            // 1단계: 유저 문서 삭제 (닉네임 포함) — 반드시 성공해야 탈퇴 진행
+            // 1단계: 유저 문서 삭제 — 반드시 성공해야 탈퇴 진행
             try await deleteUserDocument()
 
             // 2단계: 서브컬렉션 삭제 — 실패해도 탈퇴 계속 진행
             await deleteSubcollectionsSilently()
 
-            // 3단계: Firebase Auth 계정 삭제
-            try await Auth.auth().currentUser?.delete()
+            // 3단계: 기기 내 로컬 Core Data 시향기 데이터 삭제
+            try? coreDataStack.deleteAllTastingNotes()
+
+            // 4단계: Firebase 로그아웃 (Apple 재인증 없이 즉시 처리)
+            try authService.signOut()
+
             didWithdraw = true
         } catch {
-            let code = (error as NSError).code
-            // 17014: requiresRecentLogin — Apple 로그인 재인증 필요
-            if code == 17014 {
-                errorMessage = AppStrings.ViewModelMessages.Withdraw.requiresRecentLogin
-            } else {
-                errorMessage = AppStrings.ViewModelMessages.Withdraw.failed
-            }
+            errorMessage = AppStrings.ViewModelMessages.Withdraw.failed
         }
     }
 

--- a/Sniff/Presentation/common/Tab/Settings/Views/WithdrawView.swift
+++ b/Sniff/Presentation/common/Tab/Settings/Views/WithdrawView.swift
@@ -16,8 +16,8 @@ struct WithdrawView: View {
     /// 탈퇴 최종 확인 Alert 표시 여부
     @State private var showConfirmAlert: Bool = false
 
-    init(nickname: String) {
-        _viewModel = StateObject(wrappedValue: WithdrawViewModel(nickname: nickname))
+    init(viewModel: WithdrawViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {
@@ -195,7 +195,7 @@ struct WithdrawView: View {
 
 #Preview {
     NavigationStack {
-        WithdrawView(nickname: "킁킁이")
+        WithdrawView(viewModel: WithdrawViewModel(nickname: "킁킁이"))
             .environmentObject(AppStateManager())
     }
 }

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
@@ -46,7 +46,7 @@ final class TastingNoteFormViewModel: ObservableObject {
     var canSave: Bool {
         !perfumeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !brandName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        isMemoValid
+        !selectedMoodTags.isEmpty
     }
 
     var memoCount: Int { memo.count }
@@ -210,34 +210,6 @@ final class TastingNoteFormViewModel: ObservableObject {
         }
     }
 
-    private func findDuplicateNote(in ref: CollectionReference) async throws -> TastingNoteDocument? {
-        let snapshot = try await ref.getDocuments()
-        let currentKey = duplicateKey(perfumeName: perfumeName, brandName: brandName)
-
-        let matches: [TastingNoteDocument] = snapshot.documents.compactMap { document -> TastingNoteDocument? in
-            guard var note = try? document.data(as: TastingNote.self),
-                  duplicateKey(perfumeName: note.perfumeName, brandName: note.brandName) == currentKey else {
-                return nil
-            }
-            note.id = document.documentID
-            return TastingNoteDocument(id: document.documentID, note: note)
-        }
-
-        return matches
-            .sorted { lhs, rhs in lhs.note.createdAt > rhs.note.createdAt }
-            .first
-    }
-
-    private func duplicateKey(perfumeName: String, brandName: String) -> String {
-        let normalizedName = perfumeName
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        let normalizedBrand = brandName
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        return "\(normalizedBrand)|\(normalizedName)"
-    }
-
     private static func isKoreanScalar(_ scalar: UnicodeScalar) -> Bool {
         (0xAC00...0xD7A3).contains(Int(scalar.value))
     }
@@ -250,11 +222,4 @@ final class TastingNoteFormViewModel: ObservableObject {
     private static func isNumberScalar(_ scalar: UnicodeScalar) -> Bool {
         (0x30...0x39).contains(Int(scalar.value))
     }
-}
-
-private struct TastingNoteDocument {
-    let id: String
-    let note: TastingNote
-
-    var createdAt: Date { note.createdAt }
 }

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteFormView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteFormView.swift
@@ -224,14 +224,16 @@ struct TastingNoteFormView: View {
 
     private var bottomBar: some View {
         HStack(spacing: 12) {
+            // 초기화 버튼 — 고정 너비
             Button { vm.reset() } label: {
                 Text(AppStrings.TastingNoteFormUI.reset)
                     .font(.system(size: 16, weight: .semibold)).foregroundColor(.primary)
-                    .frame(maxWidth: .infinity).frame(height: 52)
+                    .frame(width: 108).frame(height: 52)
                     .background(Color(.systemGray6))
                     .clipShape(RoundedRectangle(cornerRadius: 12))
             }
 
+            // 작성 완료하기 버튼 — 나머지 공간 전체 차지
             Button { Task { await vm.save() } } label: {
                 ZStack {
                     if vm.isSaving { ProgressView().tint(.white) }

--- a/Sniff/PrivacyInfo.xcprivacy
+++ b/Sniff/PrivacyInfo.xcprivacy
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: 앱 자체 기능(컬렉션 월간 한도, 좋아요 일간 한도,
+				     검색 기록, 추천 업데이트 타임스탬프, API 응답 캐시)에
+				     필요한 데이터를 저장하기 위해 UserDefaults를 사용합니다. -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sniff/SniffApp.swift
+++ b/Sniff/SniffApp.swift
@@ -50,11 +50,10 @@ struct SniffApp: App {
         switch appStateManager.state {
         case .splash:
             SplashView()
-                .onAppear {
-                    Task {
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        await appStateManager.completeSplash()
-                    }
+                // .task modifier 사용 → View 소멸 시 Task가 자동으로 취소됩니다.
+                .task {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    await appStateManager.completeSplash()
                 }
         case .login:
             LoginSceneFactory.makeView(


### PR DESCRIPTION
## 변경 사항

### 시향기 등록 화면
- 시향 메모 필수 입력 제거, 분위기&이미지 태그 1개 이상 선택 시 작성 완료하기 버튼 활성화 구현
- 하단 버튼 레이아웃 수정

### 회원 탈퇴 로직 개선
- 탈퇴 시 Apple 로그인 재인증 제거