### PR TITLE
refactor: 마이페이지, 환경설정 페이지 2차 UI 구도화 작업 수정

### DIFF
--- a/Sniff/App/DI/AppDependencyContainer.swift
+++ b/Sniff/App/DI/AppDependencyContainer.swift
@@ -61,7 +61,8 @@ final class AppDependencyContainer {
             firestoreService: firestoreService,
             collectionRepository: makeCollectionRepository(),
             tastingRepository: makeTastingRecordRepository(),
-            localTastingNoteRepository: localTastingNoteRepository
+            localTastingNoteRepository: localTastingNoteRepository,
+            userTasteRepository: userTasteRepository
         )
     }
 

--- a/Sniff/Localization/UIStrings/AppStrings+ProfileAndSettings.swift
+++ b/Sniff/Localization/UIStrings/AppStrings+ProfileAndSettings.swift
@@ -45,11 +45,11 @@ extension AppStrings {
         enum Withdraw {
             static let title = "회원 탈퇴"
             static let appName = AppStrings.AppShell.appName
-            static let guide = "탈퇴하기 전 유의사항을 확인해주세요"
+            static let guide = "탈퇴하기 전 아래의 유의사항을 확인해주세요"
             static let noticeTitle = "계정 탈퇴 유의사항"
             static let noticeBody = "계정 탈퇴 시 서비스에 등록된 개인정보와 서비스 이용 중 작성하신 모든 글이 영구적으로 삭제되며, 다시는 복구할 수 없습니다."
             static let agreement = "계정 탈퇴 유의사항을 확인했습니다."
-            static let action = "계정 탈퇴"
+            static let action = "다음"
             static let confirmTitle = "정말 탈퇴하시겠습니까?"
             static let confirmMessage = "탈퇴 시 모든 데이터가 영구적으로 삭제되며\n복구할 수 없습니다."
             static let confirmDestructive = "탈퇴"

--- a/Sniff/Presentation/common/Components/PerfumeGridCardView.swift
+++ b/Sniff/Presentation/common/Components/PerfumeGridCardView.swift
@@ -15,7 +15,7 @@ enum PerfumeCardStyle: Equatable {
     var defaultCardWidth: CGFloat? {
         switch self {
         case .preview:
-            return 124
+            return 132
         case .grid, .listThumbnail:
             return nil
         }
@@ -23,8 +23,10 @@ enum PerfumeCardStyle: Equatable {
 
     var cornerRadius: CGFloat {
         switch self {
-        case .preview, .grid:
+        case .grid:
             return 20
+        case .preview:
+            return 10
         case .listThumbnail:
             return 18
         }
@@ -33,7 +35,7 @@ enum PerfumeCardStyle: Equatable {
     var imagePadding: CGFloat {
         switch self {
         case .preview:
-            return 0
+            return 4
         case .grid:
             return 4
         case .listThumbnail:
@@ -44,7 +46,7 @@ enum PerfumeCardStyle: Equatable {
     var innerCanvasInset: CGFloat {
         switch self {
         case .preview:
-            return 0
+            return 8
         case .grid:
             return 11
         case .listThumbnail:
@@ -72,7 +74,9 @@ enum PerfumeCardStyle: Equatable {
 
     var contentTopSpacing: CGFloat {
         switch self {
-        case .preview, .grid:
+        case .preview:
+            return stylePreviewContentTopSpacing
+        case .grid:
             return 10
         case .listThumbnail:
             return 0
@@ -81,7 +85,7 @@ enum PerfumeCardStyle: Equatable {
 
     var brandFontSize: CGFloat {
         switch self {
-        case .preview, .grid, .listThumbnail:
+        case .grid, .listThumbnail, .preview:
             return 12
         }
     }
@@ -97,7 +101,9 @@ enum PerfumeCardStyle: Equatable {
 
     var nameFontSize: CGFloat {
         switch self {
-        case .preview, .grid:
+        case .preview:
+            return stylePreviewNameFontSize
+        case .grid:
             return 16
         case .listThumbnail:
             return 17
@@ -114,21 +120,21 @@ enum PerfumeCardStyle: Equatable {
     var brandToNameSpacing: CGFloat {
         switch self {
         case .preview, .grid, .listThumbnail:
-            return 5
+            return 2
         }
     }
 
     var nameToAccordSpacing: CGFloat {
         switch self {
         case .preview, .grid, .listThumbnail:
-            return 5
+            return 4
         }
     }
 
     var textBlockHeight: CGFloat? {
         switch self {
         case .preview:
-            return 80
+            return 84
         case .grid:
             return 82
         case .listThumbnail:
@@ -138,7 +144,9 @@ enum PerfumeCardStyle: Equatable {
 
     var accordSpacing: CGFloat {
         switch self {
-        case .preview, .grid, .listThumbnail:
+        case .preview:
+            return 8
+        case .grid, .listThumbnail:
             return 10
         }
     }
@@ -159,22 +167,14 @@ enum PerfumeCardStyle: Equatable {
 
     var likeIconSize: CGFloat {
         switch self {
-        case .preview:
-            return 18
-        case .grid:
-            return 20
-        case .listThumbnail:
-            return 18
+        case .preview, .grid, .listThumbnail:
+            return 24
         }
     }
 
     var likeIconInset: CGFloat {
         switch self {
-        case .preview:
-            return 0
-        case .grid:
-            return 10
-        case .listThumbnail:
+        case .preview, .grid, .listThumbnail:
             return 8
         }
     }
@@ -182,7 +182,7 @@ enum PerfumeCardStyle: Equatable {
     var artworkWidthRatio: CGFloat {
         switch self {
         case .preview:
-            return 1
+            return 0.9
         case .grid:
             return 0.86
         case .listThumbnail:
@@ -193,7 +193,7 @@ enum PerfumeCardStyle: Equatable {
     var artworkHeightRatio: CGFloat {
         switch self {
         case .preview:
-            return 1
+            return 0.9
         case .grid:
             return 0.88
         case .listThumbnail:
@@ -203,22 +203,14 @@ enum PerfumeCardStyle: Equatable {
 
     var badgeTopInset: CGFloat {
         switch self {
-        case .preview:
-            return 6
-        case .grid:
-            return 10
-        case .listThumbnail:
+        case .preview, .grid, .listThumbnail:
             return 8
         }
     }
 
     var badgeLeadingInset: CGFloat {
         switch self {
-        case .preview:
-            return 6
-        case .grid:
-            return 10
-        case .listThumbnail:
+        case .preview, .grid, .listThumbnail:
             return 8
         }
     }
@@ -226,16 +218,16 @@ enum PerfumeCardStyle: Equatable {
     var badgeHeight: CGFloat {
         switch self {
         case .preview, .grid:
-            return 23
+            return 22
         case .listThumbnail:
-            return 30
+            return 22
         }
     }
 
     var artworkTopReservedInset: CGFloat {
         switch self {
         case .preview:
-            return badgeHeight + 4
+            return 0
         case .grid, .listThumbnail:
             return 0
         }
@@ -244,7 +236,7 @@ enum PerfumeCardStyle: Equatable {
     var imageSectionAspectRatio: CGFloat {
         switch self {
         case .preview:
-            return 0.92
+            return 1
         case .grid, .listThumbnail:
             return 1
         }
@@ -261,7 +253,7 @@ enum PerfumeCardStyle: Equatable {
 }
 
 enum PerfumeGridCardLayout {
-    static let previewCardWidth: CGFloat = 124
+    static let previewCardWidth: CGFloat = 132
     static let previewCardSpacing: CGFloat = 10
     static let previewTrailingPeekInset: CGFloat = 10
     static let gridHorizontalPadding: CGFloat = 20
@@ -274,6 +266,8 @@ enum PerfumeGridCardLayout {
 }
 
 private let perfumeArtworkBackgroundCleanupProcessor = PerfumeArtworkBackgroundCleanupProcessor()
+private let stylePreviewContentTopSpacing: CGFloat = 10
+private let stylePreviewNameFontSize: CGFloat = 14
 
 struct PerfumeGridCardView: View {
     let imageURL: String?
@@ -302,22 +296,9 @@ struct PerfumeGridCardView: View {
             )
             .padding(.top, style.contentTopSpacing)
         }
-        .padding(style == .preview ? 8 : 0)
+        .padding(0)
         .frame(width: resolvedCardWidth, alignment: .topLeading)
         .frame(maxWidth: resolvedCardWidth == nil ? .infinity : nil, alignment: .topLeading)
-        .background {
-            if style == .preview {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color(.systemBackground))
-            }
-        }
-        .clipShape(RoundedRectangle(cornerRadius: style == .preview ? 16 : 0, style: .continuous))
-        .overlay {
-            if style == .preview {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .strokeBorder(Color(uiColor: UIColor.separator.withAlphaComponent(0.12)), lineWidth: 1)
-            }
-        }
     }
 
     private var imageSection: some View {
@@ -332,11 +313,15 @@ struct PerfumeGridCardView: View {
                 Text(AppStrings.TastingNoteUI.tastingRecordBadge)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(Color(uiColor: UIColor(red: 0.43, green: 0.32, blue: 0.22, alpha: 1)))
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, 6)
                     .frame(height: style.badgeHeight)
                     .background(
-                        Capsule()
-                            .fill(Color(uiColor: UIColor(red: 0.91, green: 0.83, blue: 0.73, alpha: 1)))
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(Color(uiColor: UIColor(red: 0.96, green: 0.94, blue: 0.90, alpha: 1)))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .stroke(Color(uiColor: UIColor(red: 0.86, green: 0.84, blue: 0.80, alpha: 1)), lineWidth: 1)
                     )
                     .padding(.top, style.badgeTopInset)
                     .padding(.leading, style.badgeLeadingInset)
@@ -383,15 +368,26 @@ struct PerfumeCardArtworkView: View {
         if normalizedName.contains("another 13") || normalizedName.contains("어나더 13") {
             return 1.4
         }
-        return 1
+        switch style {
+        case .preview:
+            return 1.0
+        case .listThumbnail:
+            return 1.45
+        case .grid:
+            return 1
+        }
     }
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: style.cornerRadius)
-                .fill(style == .preview ? Color(.systemBackground) : PerfumeGridCardLayout.cardBackgroundColor)
+                .fill(Color(.systemBackground))
 
             if style != .preview {
+                RoundedRectangle(cornerRadius: style.innerCanvasCornerRadius)
+                    .fill(Color.white)
+                    .padding(style.innerCanvasInset)
+            } else {
                 RoundedRectangle(cornerRadius: style.innerCanvasCornerRadius)
                     .fill(Color.white)
                     .padding(style.innerCanvasInset)
@@ -411,6 +407,10 @@ struct PerfumeCardArtworkView: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: style.cornerRadius)
+                .stroke(Color(uiColor: UIColor.separator.withAlphaComponent(0.12)), lineWidth: 1)
+        }
     }
 
     @ViewBuilder
@@ -506,8 +506,9 @@ struct PerfumeGridCardAccordLine: View {
 
                     Text(accord)
                         .font(.system(size: style.accordFontSize, weight: .regular))
-                        .foregroundColor(Color(.systemGray2))
+                        .foregroundColor(Color(.systemGray))
                         .lineLimit(1)
+                        .minimumScaleFactor(0.82)
                 }
             }
 

--- a/Sniff/Presentation/common/Tab/MyPage/ViewModels/MyPageViewModel.swift
+++ b/Sniff/Presentation/common/Tab/MyPage/ViewModels/MyPageViewModel.swift
@@ -42,6 +42,7 @@ final class MyPageViewModel: ObservableObject {
     @Published private(set) var profileInfo: ProfileInfo?
     @Published private(set) var ownedPerfumes: [OwnedPreviewItem] = []
     @Published private(set) var likedPerfumes: [LikedPreviewItem] = []
+    @Published private(set) var tasteProfileItem: HomeViewModel.HomeProfileItem?
     @Published private(set) var ownedCount: Int = 0
     @Published private(set) var likedCount: Int = 0
     @Published private(set) var isLoading = false
@@ -60,6 +61,8 @@ final class MyPageViewModel: ObservableObject {
     private let collectionRepository: CollectionRepositoryType
     private let tastingRepository: TastingRecordRepositoryType
     private let localTastingNoteRepository: LocalTastingNoteRepository
+    private let userTasteRepository: UserTasteRepositoryType
+    private let preferenceAggregator = PreferenceAggregator()
     private var allOwnedPerfumes: [OwnedPreviewItem] = []
     private var allLikedPerfumes: [LikedPreviewItem] = []
     private var toastTask: Task<Void, Never>?
@@ -68,12 +71,14 @@ final class MyPageViewModel: ObservableObject {
         firestoreService: FirestoreService,
         collectionRepository: CollectionRepositoryType,
         tastingRepository: TastingRecordRepositoryType,
-        localTastingNoteRepository: LocalTastingNoteRepository
+        localTastingNoteRepository: LocalTastingNoteRepository,
+        userTasteRepository: UserTasteRepositoryType
     ) {
         self.firestoreService = firestoreService
         self.collectionRepository = collectionRepository
         self.tastingRepository = tastingRepository
         self.localTastingNoteRepository = localTastingNoteRepository
+        self.userTasteRepository = userTasteRepository
     }
 
     deinit {
@@ -94,11 +99,21 @@ final class MyPageViewModel: ObservableObject {
             async let likedFetch = fetchLikedPerfumesResult()
             async let tastingKeyFetch = fetchTastingKeys()
             async let tastingImageURLFetch = fetchTastingImageURLs()
+            async let tasteAnalysisFetch = fetchTasteAnalysisResult()
+            async let tastingRecordsFetch = fetchTastingRecordsResult()
 
             let collectionResult = await collectionFetch
             let likedResult = await likedFetch
             let tastingKeys = await tastingKeyFetch
             let tastingImageURLs = await tastingImageURLFetch
+            let tasteAnalysisResult = await tasteAnalysisFetch
+            let tastingRecordsResult = await tastingRecordsFetch
+
+            updateTasteProfile(
+                tasteAnalysisResult: tasteAnalysisResult,
+                collectionResult: collectionResult,
+                tastingRecordsResult: tastingRecordsResult
+            )
 
             switch collectionResult {
             case .success(let collection):
@@ -323,6 +338,47 @@ private extension MyPageViewModel {
         } catch {
             return .failure(error)
         }
+    }
+
+    func fetchTasteAnalysisResult() async -> Result<TasteAnalysisResult, Error> {
+        do {
+            return .success(try await userTasteRepository.fetchTasteAnalysis().async())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    func fetchTastingRecordsResult() async -> Result<[TastingRecord], Error> {
+        do {
+            return .success(try await tastingRepository.fetchTastingRecords().async())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    func updateTasteProfile(
+        tasteAnalysisResult: Result<TasteAnalysisResult, Error>,
+        collectionResult: Result<[CollectedPerfume], Error>,
+        tastingRecordsResult: Result<[TastingRecord], Error>
+    ) {
+        guard case .success(let tasteAnalysis) = tasteAnalysisResult else {
+            tasteProfileItem = nil
+            return
+        }
+
+        let collection = collectionResult.collectionItems
+        let tastingRecords = tastingRecordsResult.tastingRecords
+        let profile = preferenceAggregator.aggregate(
+            onboarding: tasteAnalysis,
+            collection: collection,
+            tastingRecords: tastingRecords
+        )
+
+        tasteProfileItem = HomeViewModel.HomeProfileItem(
+            profile: profile,
+            collectionCount: collection.count,
+            tastingCount: tastingRecords.count
+        )
     }
 
     func makeOwnedPreviewItem(from perfume: CollectedPerfume) -> OwnedPreviewItem {
@@ -591,6 +647,13 @@ private extension Result where Success == [LikedPerfume], Failure == Error {
     }
 }
 
+private extension Result where Success == [TastingRecord], Failure == Error {
+    var tastingRecords: [TastingRecord] {
+        guard case .success(let records) = self else { return [] }
+        return records
+    }
+}
+
 // MARK: - Preview 전용 목 데이터
 
 #if DEBUG
@@ -604,10 +667,26 @@ extension MyPageViewModel {
             firestoreService: dependencyContainer.firestoreService,
             collectionRepository: dependencyContainer.makeCollectionRepository(),
             tastingRepository: dependencyContainer.makeTastingRecordRepository(),
-            localTastingNoteRepository: dependencyContainer.localTastingNoteRepository
+            localTastingNoteRepository: dependencyContainer.localTastingNoteRepository,
+            userTasteRepository: dependencyContainer.userTasteRepository
         )
         vm.isMock = true
         vm.profileInfo = ProfileInfo(nickname: "강지수", email: "asdgh1423@gmail.com")
+        vm.tasteProfileItem = HomeViewModel.HomeProfileItem(
+            profile: UserTasteProfile(
+                tasteTitle: "깨끗하고 자연스러운 취향",
+                analysisSummary: "시트러스나 워터리 계열처럼 가볍고 산뜻한 향으로 부담 없이 시작해보시는 걸 추천해요.",
+                preferredImpressions: ["깨끗한", "자연스러운"],
+                preferredFamilies: ["Citrus", "Water"],
+                intensityLevel: "light",
+                safeStartingPoint: "Citrus",
+                familyScores: ["Citrus": 0.6, "Water": 0.4],
+                scentVector: ["Citrus": 0.6, "Water": 0.4],
+                stage: .onboardingCollection
+            ),
+            collectionCount: 3,
+            tastingCount: 2
+        )
         vm.ownedCount = 3
         vm.ownedPerfumes = [
             OwnedPreviewItem(

--- a/Sniff/Presentation/common/Tab/MyPage/Views/MyPageView.swift
+++ b/Sniff/Presentation/common/Tab/MyPage/Views/MyPageView.swift
@@ -14,23 +14,24 @@ struct MyPageView: View {
     @StateObject private var viewModel: MyPageViewModel
 
     private enum Layout {
-        static let horizontalPadding: CGFloat = 20
-        static let headerTopPadding: CGFloat = 12
-        static let sectionSpacing: CGFloat = 30
+        static let horizontalPadding: CGFloat = 16
+        static let headerTopPadding: CGFloat = 18
+        static let sectionSpacing: CGFloat = 36
         static let sectionContentSpacing: CGFloat = 10
         static let sectionHeaderBottomSpacing: CGFloat = 4
-        static let profileTopSpacing: CGFloat = 10
-        static let profileBottomSpacing: CGFloat = 12
-        static let profileImageSize: CGFloat = 84
-        static let profileTextSpacing: CGFloat = 8
-        static let cardSpacing: CGFloat = 18
+        static let profileTopSpacing: CGFloat = 18
+        static let profileBottomSpacing: CGFloat = 8
+        static let profileImageSize: CGFloat = 60
+        static let profileTextSpacing: CGFloat = 6
+        static let profileTasteTopSpacing: CGFloat = 8
+        static let tasteIconSize: CGFloat = 18
+        static let cardSpacing: CGFloat = 16
         static let trailingPeekInset: CGFloat = PerfumeGridCardLayout.previewTrailingPeekInset
-        static let likedSectionTopSpacing: CGFloat = 18
+        static let likedSectionTopSpacing: CGFloat = 24
         static let bottomContentPadding: CGFloat = 68
 
         static var cardWidth: CGFloat {
-            let availableWidth = UIScreen.main.bounds.width - (horizontalPadding * 2)
-            return min(max(availableWidth * 0.48, 180), 196)
+            PerfumeGridCardLayout.previewCardWidth
         }
     }
 
@@ -91,7 +92,7 @@ struct MyPageView: View {
     private var headerSection: some View {
         HStack(alignment: .center) {
             Text(AppStrings.Profile.MyPage.title)
-                .font(.system(size: 25, weight: .bold))
+                .font(.system(size: 22, weight: .semibold))
                 .foregroundColor(.primary)
 
             Spacer()
@@ -100,8 +101,8 @@ struct MyPageView: View {
                 SettingsSceneFactory.makeSettingsView()
             } label: {
                 Image(systemName: "gearshape")
-                    .font(.system(size: 21, weight: .semibold))
-                    .foregroundColor(.primary)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundColor(Color(.systemGray))
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
@@ -109,23 +110,70 @@ struct MyPageView: View {
     }
 
     private var profileSection: some View {
-        HStack(spacing: 16) {
-            CheckerboardProfilePlaceholder()
-                .frame(width: Layout.profileImageSize, height: Layout.profileImageSize)
-
+        HStack(alignment: .center, spacing: 16) {
             VStack(alignment: .leading, spacing: Layout.profileTextSpacing) {
                 Text(viewModel.profileInfo?.nickname ?? AppStrings.Profile.userFallback)
-                    .font(.system(size: 21, weight: .bold))
+                    .font(.system(size: 22, weight: .bold))
                     .foregroundColor(.primary)
 
                 Text(viewModel.profileInfo?.email ?? AppStrings.Profile.missingEmail)
-                    .font(.system(size: 16, weight: .regular))
-                    .foregroundColor(Color(.systemGray))
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundColor(Color(.systemGray2))
                     .lineLimit(1)
+
+                tasteProfileNavigation
+                    .padding(.top, Layout.profileTasteTopSpacing)
             }
+
+            Spacer(minLength: 16)
+
+            CheckerboardProfilePlaceholder()
+                .frame(width: Layout.profileImageSize, height: Layout.profileImageSize)
         }
         .padding(.top, Layout.profileTopSpacing)
         .padding(.bottom, Layout.profileBottomSpacing)
+    }
+
+    @ViewBuilder
+    private var tasteProfileNavigation: some View {
+        if let tasteProfileItem = viewModel.tasteProfileItem {
+            NavigationLink {
+                TasteProfileDestinationView(profileItem: tasteProfileItem)
+                    .toolbar(.hidden, for: .navigationBar)
+            } label: {
+                tasteProfileRow(title: tasteProfileItem.profile.displayTitle)
+            }
+            .buttonStyle(.plain)
+        } else {
+            tasteProfileRow(title: "취향을 분석하는 중이에요")
+                .opacity(0.65)
+        }
+    }
+
+    private func tasteProfileRow(title: String) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.94, green: 0.62, blue: 0.73),
+                            Color(red: 0.98, green: 0.95, blue: 0.88)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: Layout.tasteIconSize, height: Layout.tasteIconSize)
+
+            Text(title)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(Color(.systemGray))
+                .lineLimit(1)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(Color(.systemGray))
+        }
     }
 
     private var ownedSection: some View {
@@ -208,12 +256,12 @@ struct MyPageView: View {
     ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Text(title)
-                .font(.system(size: 22, weight: .bold))
+                .font(.system(size: 18, weight: .semibold))
                 .foregroundColor(.primary)
 
             Text(AppStrings.Profile.MyPage.count(count))
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.secondary)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(Color(.systemGray))
 
             Spacer()
 
@@ -221,8 +269,8 @@ struct MyPageView: View {
                 destination
             } label: {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(Color(.systemGray2))
                     .frame(width: 28, height: 28)
             }
             .buttonStyle(.plain)
@@ -337,6 +385,16 @@ private struct CheckerboardProfilePlaceholder: View {
             }
         }
     }
+}
+
+private struct TasteProfileDestinationView: UIViewControllerRepresentable {
+    let profileItem: HomeViewModel.HomeProfileItem
+
+    func makeUIViewController(context: Context) -> TasteProfileViewController {
+        TasteProfileViewController(profileItem: profileItem)
+    }
+
+    func updateUIViewController(_ uiViewController: TasteProfileViewController, context: Context) {}
 }
 
 #if DEBUG

--- a/Sniff/Presentation/common/Tab/Settings/Views/SettingsView.swift
+++ b/Sniff/Presentation/common/Tab/Settings/Views/SettingsView.swift
@@ -20,45 +20,16 @@ struct SettingsView: View {
     var body: some View {
         VStack(spacing: 0) {
             customHeader
-            Divider()
 
             ScrollView(showsIndicators: false) {
-                VStack(spacing: 24) {
-                    settingsSection {
-                        accountCell
-                    }
+                VStack(alignment: .leading, spacing: 0) {
+                    accountCell
 
-                    settingsSection {
-                        NavigationLink {
-                            PrivacyPolicyView()
-                        } label: {
-                            settingsRow(title: AppStrings.Profile.SettingsScreen.privacyPolicy)
-                        }
-                        .buttonStyle(.plain)
-
-                        settingsRow(
-                            title: AppStrings.Profile.SettingsScreen.appVersion,
-                            trailing: AppStrings.Profile.SettingsScreen.currentVersion(viewModel.appVersion),
-                            showsChevron: false
-                        )
-
-                        Button {
-                            viewModel.showLogoutAlert = true
-                        } label: {
-                            settingsRow(title: AppStrings.Profile.SettingsScreen.logout, tint: .red, showsChevron: false)
-                        }
-                        .buttonStyle(.plain)
-
-                        NavigationLink {
-                            SettingsSceneFactory.makeWithdrawView(nickname: viewModel.nickname)
-                        } label: {
-                            settingsRow(title: AppStrings.Profile.SettingsScreen.withdraw, tint: Color(.systemGray), showsChevron: false)
-                        }
-                        .buttonStyle(.plain)
-                    }
+                    settingsList
+                        .padding(.top, 54)
                 }
                 .padding(.horizontal, 20)
-                .padding(.top, 24)
+                .padding(.top, 3)
             }
         }
         .background(Color(.systemBackground).ignoresSafeArea())
@@ -91,7 +62,7 @@ struct SettingsView: View {
                 dismiss()
             } label: {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(.system(size: 22, weight: .semibold))
                     .foregroundColor(.primary)
                     .frame(width: 44, height: 44)
             }
@@ -103,39 +74,78 @@ struct SettingsView: View {
             Spacer()
         }
         .padding(.horizontal, 12)
-        .padding(.top, 8)
-        .padding(.bottom, 4)
+        .padding(.top, -6)
+        .padding(.bottom, 16)
     }
 
     private var accountCell: some View {
-        HStack(alignment: .center, spacing: 0) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(viewModel.nickname)
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.primary)
+        VStack(alignment: .leading, spacing: 8) {
+            Text(viewModel.nickname)
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minHeight: 26, alignment: .leading)
 
-                if let email = viewModel.email, !email.isEmpty {
-                    Text(email)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
+            if let email = viewModel.email, !email.isEmpty {
+                Text(email)
+                    .font(.system(size: 15))
+                    .foregroundColor(Color(.systemGray2))
+                    .lineLimit(1)
             }
-
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func settingsSection<Content: View>(
-        @ViewBuilder content: () -> Content
-    ) -> some View {
+    private var settingsList: some View {
         VStack(spacing: 0) {
-            content()
+            NavigationLink {
+                PrivacyPolicyView()
+            } label: {
+                settingsRow(title: AppStrings.Profile.SettingsScreen.privacyPolicy)
+            }
+            .buttonStyle(.plain)
+
+            separator
+
+            settingsRow(
+                title: AppStrings.Profile.SettingsScreen.appVersion,
+                trailing: AppStrings.Profile.SettingsScreen.currentVersion(viewModel.appVersion),
+                showsChevron: false
+            )
+
+            separator
+
+            Button {
+                viewModel.showLogoutAlert = true
+            } label: {
+                settingsRow(
+                    title: AppStrings.Profile.SettingsScreen.logout,
+                    tint: Color(red: 1, green: 0.26, blue: 0.26),
+                    showsChevron: false
+                )
+            }
+            .buttonStyle(.plain)
+
+            separator
+
+            NavigationLink {
+                SettingsSceneFactory.makeWithdrawView(nickname: viewModel.nickname)
+            } label: {
+                settingsRow(
+                    title: AppStrings.Profile.SettingsScreen.withdraw,
+                    tint: Color(.systemGray2),
+                    showsChevron: false
+                )
+            }
+            .buttonStyle(.plain)
         }
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var separator: some View {
+        Rectangle()
+            .fill(Color(.systemGray5))
+            .frame(height: 1)
     }
 
     private func settingsRow(
@@ -146,7 +156,7 @@ struct SettingsView: View {
     ) -> some View {
         HStack(spacing: 12) {
             Text(title)
-                .font(.system(size: 16))
+                .font(.system(size: 16, weight: .regular))
                 .foregroundColor(tint)
 
             Spacer()
@@ -159,12 +169,11 @@ struct SettingsView: View {
 
             if showsChevron {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Color(.systemGray3))
             }
         }
-        .padding(.horizontal, 16)
-        .frame(height: 54)
+        .frame(height: 55)
         .contentShape(Rectangle())
     }
 }

--- a/Sniff/Presentation/common/Tab/Settings/Views/WithdrawView.swift
+++ b/Sniff/Presentation/common/Tab/Settings/Views/WithdrawView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import CoreText
 
 // MARK: - 회원탈퇴 확인 화면
 
@@ -23,37 +24,39 @@ struct WithdrawView: View {
     var body: some View {
         VStack(spacing: 0) {
             customHeader
-            Divider()
 
-            // 스크롤 영역 (로고 + 닉네임/안내 + 유의사항 박스)
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    // 킁킁 로고 워드마크
                     sniffLogo
 
-                    // 닉네임 + 안내 문구
-                    VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: 8) {
                         Text(AppStrings.Profile.Withdraw.nickname(viewModel.nickname))
-                            .font(.system(size: 18, weight: .bold))
+                            .font(.system(size: 16, weight: .medium))
                             .foregroundColor(.primary)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(minHeight: 22, alignment: .leading)
 
                         Text(AppStrings.Profile.Withdraw.guide)
-                            .font(.system(size: 18, weight: .bold))
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(.primary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(minHeight: 22, alignment: .leading)
                     }
-                    .padding(.top, 32)
+                    .padding(.top, 16)
 
-                    // 유의사항 박스
                     noticeBox
-                        .padding(.top, 28)
+                        .padding(.top, 22)
+
+                    agreementRow
+                        .padding(.top, 20)
                 }
-                .padding(.horizontal, 24)
-                .padding(.top, 32)
+                .padding(.horizontal, 20)
+                .padding(.top, 24)
                 .padding(.bottom, 24)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            // 하단 고정: 구분선 + 체크박스 + 탈퇴 버튼
             bottomSection
         }
         .background(Color(.systemBackground).ignoresSafeArea())
@@ -105,31 +108,29 @@ struct WithdrawView: View {
             }
 
             Text(AppStrings.Profile.Withdraw.title)
-                .font(.system(size: 24, weight: .bold))
+                .font(.system(size: 20, weight: .bold))
                 .foregroundColor(.primary)
 
             Spacer()
         }
         .padding(.horizontal, 12)
-        .padding(.top, 8)
-        .padding(.bottom, 4)
+        .padding(.top, -6)
+        .padding(.bottom, 14)
     }
 
     // MARK: - 킁킁 로고
 
     private var sniffLogo: some View {
-        Text(AppStrings.Profile.Withdraw.appName)
-            .font(.system(size: 32, weight: .heavy))
-            .foregroundColor(.primary)
-            .tracking(-1)
+        HahmletLogoText(text: AppStrings.Profile.Withdraw.appName)
+            .frame(width: 47, height: 37, alignment: .leading)
     }
 
     // MARK: - 유의사항 박스
 
     private var noticeBox: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 8) {
             Text(AppStrings.Profile.Withdraw.noticeTitle)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.primary)
 
             Text(AppStrings.Profile.Withdraw.noticeBody)
@@ -140,56 +141,129 @@ struct WithdrawView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .background(Color(red: 0.98, green: 0.96, blue: 0.94))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
     // MARK: - 하단 고정 섹션
 
     private var bottomSection: some View {
         VStack(spacing: 0) {
-            Divider()
+            Button {
+                showConfirmAlert = true
+            } label: {
+                Text(AppStrings.Profile.Withdraw.action)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(viewModel.isAgreed ? Color(red: 0.1, green: 0.1, blue: 0.1) : Color(.systemGray5))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .disabled(!viewModel.isAgreed)
+            .animation(.easeInOut(duration: 0.15), value: viewModel.isAgreed)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+        .padding(.bottom, 20)
+        .background(Color(.systemBackground))
+    }
 
-            VStack(spacing: 12) {
-                // 동의 체크박스
-                Button {
-                    viewModel.isAgreed.toggle()
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: viewModel.isAgreed ? "checkmark.square.fill" : "square")
-                            .font(.system(size: 20))
-                            .foregroundColor(viewModel.isAgreed ? Color(.systemGray) : Color(.systemGray3))
+    private var agreementRow: some View {
+        Button {
+            viewModel.isAgreed.toggle()
+        } label: {
+            HStack(spacing: 8) {
+                checkbox
 
-                        Text(AppStrings.Profile.Withdraw.agreement)
-                            .font(.system(size: 14))
-                            .foregroundColor(.primary)
+                Text(AppStrings.Profile.Withdraw.agreement)
+                    .font(.custom("Pretendard", size: 15).weight(.medium))
+                    .foregroundColor(viewModel.isAgreed ? Color(red: 0.3, green: 0.3, blue: 0.3) : Color(red: 0.5, green: 0.5, blue: 0.5))
 
-                        Spacer()
-                    }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 16)
-                }
-                .buttonStyle(.plain)
-                .animation(.easeInOut(duration: 0.1), value: viewModel.isAgreed)
-
-                // 계정 탈퇴 버튼
-                Button {
-                    showConfirmAlert = true
-                } label: {
-                    Text(AppStrings.Profile.Withdraw.action)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(viewModel.isAgreed ? .primary : Color(.systemGray2))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 52)
-                        .background(viewModel.isAgreed ? Color(.systemGray5) : Color(.systemGray6))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .padding(.horizontal, 24)
-                }
-                .disabled(!viewModel.isAgreed)
-                .animation(.easeInOut(duration: 0.15), value: viewModel.isAgreed)
-                .padding(.bottom, 20)
+                Spacer()
             }
         }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.1), value: viewModel.isAgreed)
+    }
+
+    private var checkbox: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(viewModel.isAgreed ? Color.black : Color.white)
+
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(viewModel.isAgreed ? Color.black : Color(red: 0.7, green: 0.7, blue: 0.7), lineWidth: 1)
+
+            if viewModel.isAgreed {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+            }
+        }
+        .frame(width: 24, height: 24)
+    }
+}
+
+private struct HahmletLogoText: UIViewRepresentable {
+
+    let text: String
+
+    func makeUIView(context: Context) -> UILabel {
+        let label = UILabel()
+        label.backgroundColor = .clear
+        label.numberOfLines = 1
+        label.lineBreakMode = .byClipping
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return label
+    }
+
+    func updateUIView(_ label: UILabel, context: Context) {
+        HahmletFontLoader.registerIfNeeded()
+
+        let font = HahmletFontLoader.logoFont(size: 24)
+        label.attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .kern: 2,
+                .foregroundColor: UIColor.black
+            ]
+        )
+    }
+}
+
+private enum HahmletFontLoader {
+
+    private static var didRegister = false
+
+    static func registerIfNeeded() {
+        guard !didRegister else { return }
+        didRegister = true
+
+        [
+            ("Hahmlet-Bold", "ttf"),
+            ("Hahmlet-Bold", "otf"),
+            ("Hahmlet", "ttf"),
+            ("Hahmlet", "otf"),
+            ("Hahmlet-VariableFont_wght", "ttf")
+        ].forEach { name, ext in
+            guard let url = Bundle.main.url(forResource: name, withExtension: ext) else { return }
+            CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+        }
+    }
+
+    static func logoFont(size: CGFloat) -> UIFont {
+        if let font = UIFont(name: "Hahmlet-Bold", size: size) {
+            return font
+        }
+
+        if let font = UIFont(name: "Hahmlet", size: size) {
+            return font
+        }
+
+        return .systemFont(ofSize: size, weight: .bold)
     }
 }
 

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/LikedPerfumeListView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/LikedPerfumeListView.swift
@@ -11,15 +11,15 @@ struct LikedPerfumeListView: View {
     @StateObject private var viewModel: LikedPerfumeListViewModel
     @Environment(\.dismiss) private var dismiss
     private enum Layout {
-        static let horizontalPadding: CGFloat = PerfumeGridCardLayout.listHorizontalPadding
-        static let rowSpacing: CGFloat = 30
-        static let thumbnailSize: CGFloat = 92
-        static let rowVerticalPadding: CGFloat = 6
-        static let contentSpacing: CGFloat = 20
-        static let inlineInfoSpacing: CGFloat = 8
-        static let nameToMetaSpacing: CGFloat = 5
-        static let badgeTopSpacing: CGFloat = 7
-        static let heartSize: CGFloat = 29
+        static let horizontalPadding: CGFloat = 16
+        static let rowSpacing: CGFloat = 12
+        static let thumbnailSize: CGFloat = 72
+        static let rowVerticalPadding: CGFloat = 12
+        static let contentSpacing: CGFloat = 16
+        static let inlineInfoSpacing: CGFloat = 6
+        static let nameToMetaSpacing: CGFloat = 4
+        static let badgeTopSpacing: CGFloat = 10
+        static let heartSize: CGFloat = 24
     }
 
     init(viewModel: LikedPerfumeListViewModel) {
@@ -71,22 +71,22 @@ struct LikedPerfumeListView: View {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 20, weight: .semibold))
                     .foregroundColor(.primary)
-                    .frame(width: 44, height: 44)
+                    .frame(width: 36, height: 44)
             }
 
             Text(AppStrings.TastingNoteUI.LikedList.title)
-                .font(.system(size: 24, weight: .bold))
+                .font(.system(size: 20, weight: .semibold))
                 .foregroundColor(.primary)
 
             Text(AppStrings.TastingNoteUI.LikedList.count(viewModel.perfumeCount))
-                .font(.system(size: 22, weight: .medium))
+                .font(.system(size: 16, weight: .medium))
                 .foregroundColor(Color(.systemGray2))
 
             Spacer()
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, Layout.horizontalPadding)
         .padding(.top, 14)
-        .padding(.bottom, 20)
+        .padding(.bottom, 10)
     }
 
     // MARK: - 빈 상태
@@ -144,12 +144,13 @@ struct LikedPerfumeListView: View {
     }
 
     private func perfumeRowContent(_ perfume: LikedPerfumeListViewModel.PerfumeRowItem) -> some View {
-        HStack(alignment: .top, spacing: Layout.contentSpacing) {
+        // 시향 기록이 있으면 상단 정렬, 없으면 중앙 정렬
+        HStack(alignment: perfume.hasTastingRecord ? .top : .center, spacing: Layout.contentSpacing) {
             perfumeImage(url: perfume.imageURL)
 
             VStack(alignment: .leading, spacing: 0) {
                 Text(PerfumePresentationSupport.displayPerfumeName(perfume.name))
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: 15, weight: .medium))
                     .foregroundColor(.primary)
                     .lineLimit(1)
                     .multilineTextAlignment(.leading)
@@ -184,7 +185,7 @@ struct LikedPerfumeListView: View {
 
     private var tastingRecordBadge: some View {
         Text(AppStrings.TastingNoteUI.tastingRecordBadge)
-            .font(.system(size: 11, weight: .medium))
+            .font(.system(size: 13, weight: .semibold))
             .foregroundColor(Color(uiColor: UIColor(red: 0.47, green: 0.39, blue: 0.31, alpha: 1)))
             .padding(.horizontal, 9)
             .padding(.vertical, 5)
@@ -197,9 +198,13 @@ struct LikedPerfumeListView: View {
 
         return HStack(spacing: Layout.inlineInfoSpacing) {
             Text(PerfumePresentationSupport.displayBrand(brand))
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.secondary)
                 .lineLimit(1)
+
+            Text("|")
+                .font(.system(size: 13, weight: .regular))
+                .foregroundColor(Color(.systemGray3))
 
             ForEach(Array(displayAccords.enumerated()), id: \.offset) { index, accord in
                 HStack(spacing: 4) {
@@ -208,8 +213,8 @@ struct LikedPerfumeListView: View {
                         .frame(width: 7, height: 7)
 
                     Text(accord)
-                        .font(.system(size: 12, weight: .regular))
-                        .foregroundColor(Color(.systemGray2))
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundColor(Color(.systemGray))
                         .lineLimit(1)
                 }
             }

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/OwnedPerfumeListView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/OwnedPerfumeListView.swift
@@ -10,12 +10,11 @@ struct OwnedPerfumeListView: View {
 
     @StateObject private var viewModel: OwnedPerfumeListViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var showsMonthlyUsageInfo = false
     private enum Layout {
-        static let horizontalPadding: CGFloat = PerfumeGridCardLayout.gridHorizontalPadding
-        static let columnSpacing: CGFloat = PerfumeGridCardLayout.gridColumnSpacing
-        static let rowSpacing: CGFloat = PerfumeGridCardLayout.gridRowSpacing
-        static let selectionInset: CGFloat = 5
+        static let horizontalPadding: CGFloat = 16
+        static let columnSpacing: CGFloat = 14
+        static let rowSpacing: CGFloat = 32
+        static let selectionInset: CGFloat = 8
     }
 
     init(viewModel: OwnedPerfumeListViewModel) {
@@ -82,54 +81,24 @@ struct OwnedPerfumeListView: View {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.primary)
-                    .frame(width: 44, height: 44)
+                    .frame(width: 36, height: 44)
             }
 
             // 타이틀 (왼쪽 정렬)
             if viewModel.isEditMode {
                 Text(AppStrings.TastingNoteUI.OwnedList.editTitle)
-                    .font(.system(size: 24, weight: .bold))
+                    .font(.system(size: 20, weight: .semibold))
                     .foregroundColor(.primary)
             } else {
                 HStack(spacing: 6) {
                     Text(AppStrings.TastingNoteUI.OwnedList.title)
-                        .font(.system(size: 24, weight: .bold))
+                        .font(.system(size: 20, weight: .semibold))
                         .foregroundColor(.primary)
 
                     Text(AppStrings.TastingNoteUI.OwnedList.count(viewModel.perfumeCount))
-                        .font(.system(size: 22, weight: .medium))
+                        .font(.system(size: 16, weight: .medium))
                         .foregroundColor(Color(.systemGray2))
 
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.22)) {
-                            showsMonthlyUsageInfo.toggle()
-                        }
-                    } label: {
-                        ZStack {
-                            if showsMonthlyUsageInfo {
-                                Text(AppStrings.CollectionUsageLimits.monthlyUsage(
-                                    viewModel.monthlyUsageCount,
-                                    limit: viewModel.monthlyUsageLimit
-                                ))
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundColor(Color(.systemGray))
-                                .padding(.horizontal, 9)
-                                .frame(height: 26)
-                                .background(Color(.systemGray6))
-                                .clipShape(Capsule())
-                                .transition(.move(edge: .trailing).combined(with: .opacity))
-                            } else {
-                                Text("!")
-                                    .font(.system(size: 13, weight: .bold))
-                                    .foregroundColor(Color(.systemGray))
-                                    .frame(width: 22, height: 22)
-                                    .background(Color(.systemGray6))
-                                    .clipShape(Circle())
-                                    .transition(.move(edge: .trailing).combined(with: .opacity))
-                            }
-                        }
-                    }
-                    .buttonStyle(.plain)
                 }
             }
 
@@ -143,14 +112,14 @@ struct OwnedPerfumeListView: View {
                     viewModel.toggleEditMode()
                 }
             }
-            .font(.system(size: 16, weight: .medium))
-            .foregroundColor(viewModel.isEditMode ? .red : .primary)
+            .font(.system(size: 18, weight: .medium))
+            .foregroundColor(viewModel.isEditMode ? Color(red: 1, green: 0.26, blue: 0.26) : Color(.systemGray))
             .disabled(viewModel.isEditMode && !viewModel.hasSelection)
             .opacity(viewModel.isEditMode && !viewModel.hasSelection ? 0.35 : 1)
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, 15)
         .padding(.top, 14)
-        .padding(.bottom, 20)
+        .padding(.bottom, 12)
     }
 
     // MARK: - 빈 상태
@@ -217,9 +186,7 @@ struct OwnedPerfumeListView: View {
             )
 
             if viewModel.isEditMode {
-                Image(systemName: viewModel.selectedPerfumeIDs.contains(perfume.id) ? "checkmark.square.fill" : "square")
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundColor(viewModel.selectedPerfumeIDs.contains(perfume.id) ? Color(.systemGray) : Color(.systemGray3))
+                selectionCheckbox(isSelected: viewModel.selectedPerfumeIDs.contains(perfume.id))
                     .padding(.top, Layout.selectionInset)
                     .padding(.leading, Layout.selectionInset)
             }
@@ -259,14 +226,40 @@ struct OwnedPerfumeListView: View {
     }
 
     private func toastView(_ message: String) -> some View {
-        Text(message)
-            .font(.system(size: 15, weight: .medium))
-            .foregroundColor(.white)
-            .padding(.horizontal, 20)
-            .frame(maxWidth: .infinity)
-            .frame(height: 52)
-            .background(Color.black.opacity(0.85))
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+        HStack(alignment: .center, spacing: 8) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .frame(width: 24, height: 24)
+                .foregroundColor(Color.white.opacity(0.5))
+
+            Text(message)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.white)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+        .background(Color(red: 0.18, green: 0.16, blue: 0.14))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .opacity(0.8)
+    }
+
+    private func selectionCheckbox(isSelected: Bool) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isSelected ? Color.black : Color.white)
+
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(isSelected ? Color.black : Color(.systemGray), lineWidth: 1.5)
+
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+            }
+        }
+        .frame(width: 24, height: 24)
     }
 }
 

--- a/Sniff/Utils/ScentFamilyColor.swift
+++ b/Sniff/Utils/ScentFamilyColor.swift
@@ -49,17 +49,17 @@ enum ScentFamilyColor {
 
         switch true {
         case normalized.contains("fresh floral"), normalized.contains("프레시 플로럴"):
-            return UIColor(hex: "#E56BAA")
+            return UIColor(hex: "#F29388")
         case normalized.contains("soft floral"),
              normalized.contains("소프트 플로럴"),
              normalized.contains("white floral"),
              normalized.contains("화이트 플로럴"):
-            return UIColor(hex: "#E56BAA")
+            return UIColor(hex: "#F29388")
         case normalized.contains("floral oriental"),
              normalized.contains("플로럴 오리엔탈"),
              normalized.contains("floral amber"),
              normalized.contains("플로럴 앰버"):
-            return UIColor(hex: "#EC008C")
+            return UIColor(hex: "#B7647B")
         case normalized == "floral",
              normalized.contains(" floral"),
              normalized.contains("floral "),
@@ -88,17 +88,17 @@ enum ScentFamilyColor {
              normalized.contains("네롤리"),
              normalized.contains("orange blossom"),
              normalized.contains("오렌지 블로섬"):
-            return UIColor(hex: "#F53D32")
+            return UIColor(hex: "#F29388")
         case normalized.contains("soft oriental"),
              normalized.contains("소프트 오리엔탈"),
              normalized.contains("soft amber"),
              normalized.contains("소프트 앰버"):
-            return UIColor(hex: "#D4148E")
+            return UIColor(hex: "#B7647B")
         case normalized == "oriental",
              normalized.contains("오리엔탈"),
              normalized == "amber",
              normalized.contains("앰버"):
-            return UIColor(hex: "#AF003D")
+            return UIColor(hex: "#B7647B")
         case normalized.contains("woody oriental"),
              normalized.contains("우디 오리엔탈"),
              normalized.contains("woody amber"),
@@ -149,10 +149,10 @@ enum ScentFamilyColor {
              normalized.contains("머스크"),
              normalized.contains("머스키"),
              normalized.contains("spic"):
-            return UIColor(hex: "#5B5796")
+            return UIColor(hex: "#68629D")
         case normalized.contains("citrus"),
              normalized.contains("시트러스"):
-            return UIColor(hex: "#FFD900")
+            return UIColor(hex: "#FFD22E")
         case normalized.contains("water"),
              normalized.contains("워터"),
              normalized.contains("aqua"),
@@ -166,15 +166,15 @@ enum ScentFamilyColor {
             return UIColor(hex: "#1D99C4")
         case normalized.contains("green"),
              normalized.contains("그린"):
-            return UIColor(hex: "#75C062")
+            return UIColor(hex: "#72BE68")
         case normalized.contains("fresh"),
              normalized.contains("프레시"),
              normalized.contains("프레쉬"):
-            return UIColor(hex: "#75C062")
+            return UIColor(hex: "#72BE68")
         case normalized.contains("fruit"),
              normalized.contains("fruity"),
              normalized.contains("프루티"):
-            return UIColor(hex: "#FF7A1A")
+            return UIColor(hex: "#E7A175")
         default:
             return UIColor.systemGray3
         }


### PR DESCRIPTION
## 마이페이지
- 마이페이지 UI 수정
    - [x]  보유 · LIKE 향수 카드 안에 시향 기록 뱃지의 모양하고 배경 · 글씨 색상 수정
    - [x]  보유 · LIKE 향수 카드 안에 향 계열 영어로 된 부분 한글로 번역해서 보여주기
    - [x]  보유 · LIKE 향수 카드 안에 하트 위치를 지금 위치보다 왼쪽 위로 수정

- 보유 향수 페이지 UI 수정
    -카드 안에 시향 기록 뱃지의 모양하고 배경 · 글씨 색상 수정

- LIKE 향수 페이지 UI 수정
    - 향수명 · 브랜드명 · 향 계열의 배열을 셀의 크기 가운데로 배열
    - 시향 기록을 작성한 향수가 있다면 셀의 크기에 맞춰서 배열
    - 하트의 크기 조금 줄이고, 위치를 가운데로 배열

## 환경설정 페이지
- 환경설정 페이지 카드 창 제외
- 회원탈퇴 페이지 2차 UI 고도화 작업
- 탈퇴 -> 다음 수정