### PR TITLE
feat: 오프라인 시향기 향수명 후보 매칭 추가

### DIFF
--- a/Sniff/App/DI/AppDependencyContainer.swift
+++ b/Sniff/App/DI/AppDependencyContainer.swift
@@ -24,6 +24,9 @@ final class AppDependencyContainer {
         coreDataStack: coreDataStack,
         userTasteRepository: userTasteRepository
     )
+    lazy var localPerfumeSearchService = LocalPerfumeSearchService(
+        firestoreService: firestoreService
+    )
 
     func makePerfumeCatalogRepository() -> PerfumeCatalogRepositoryType {
         PerfumeCatalogRepository()
@@ -101,12 +104,15 @@ final class AppDependencyContainer {
     @MainActor
     func makeTastingNoteFormViewModel(
         editingNote: TastingNote? = nil,
-        initialPerfume: Perfume? = nil
+        initialPerfume: Perfume? = nil,
+        isOwnedPerfumeContext: Bool = false
     ) -> TastingNoteFormViewModel {
         TastingNoteFormViewModel(
             localRepository: localTastingNoteRepository,
+            localPerfumeSearchService: localPerfumeSearchService,
             editingNote: editingNote,
-            initialPerfume: initialPerfume
+            initialPerfume: initialPerfume,
+            isOwnedPerfumeContext: isOwnedPerfumeContext
         )
     }
 

--- a/Sniff/App/DI/SearchSceneFactory.swift
+++ b/Sniff/App/DI/SearchSceneFactory.swift
@@ -32,7 +32,7 @@ enum SearchSceneFactory {
         let viewModel = SearchViewModel(
             perfumeCatalogRepository: dependencyContainer.makePerfumeCatalogRepository(),
             recentSearchStore: dependencyContainer.makeRecentSearchStore(),
-            initialState: showsRecentOnAppear ? .initial : .landing
+            initialState: showsRecentOnAppear && mode != .register ? .initial : .landing
         )
         return SearchViewController(
             viewModel: viewModel,

--- a/Sniff/App/DI/TastingNoteSceneFactory.swift
+++ b/Sniff/App/DI/TastingNoteSceneFactory.swift
@@ -68,11 +68,13 @@ enum TastingNoteSceneFactory {
     static func makeFormView(
         editingNote: TastingNote? = nil,
         initialPerfume: Perfume? = nil,
+        isOwnedPerfumeContext: Bool = false,
         onSaveSuccess: @escaping (String) -> Void = { _ in }
     ) -> TastingNoteFormView {
         makeFormView(
             editingNote: editingNote,
             initialPerfume: initialPerfume,
+            isOwnedPerfumeContext: isOwnedPerfumeContext,
             dependencyContainer: AppDependencyContainer(),
             onSaveSuccess: onSaveSuccess
         )
@@ -82,13 +84,15 @@ enum TastingNoteSceneFactory {
     static func makeFormView(
         editingNote: TastingNote? = nil,
         initialPerfume: Perfume? = nil,
+        isOwnedPerfumeContext: Bool = false,
         dependencyContainer: AppDependencyContainer,
         onSaveSuccess: @escaping (String) -> Void = { _ in }
     ) -> TastingNoteFormView {
         TastingNoteFormView(
             viewModel: dependencyContainer.makeTastingNoteFormViewModel(
                 editingNote: editingNote,
-                initialPerfume: initialPerfume
+                initialPerfume: initialPerfume,
+                isOwnedPerfumeContext: isOwnedPerfumeContext
             ),
             onSaveSuccess: onSaveSuccess
         )

--- a/Sniff/Data/Local/CollectedPerfumeCacheStore.swift
+++ b/Sniff/Data/Local/CollectedPerfumeCacheStore.swift
@@ -52,6 +52,9 @@ private struct CachedCollectedPerfume: Codable {
     let accordStrengths: [String: String]
     let memo: String?
     let createdAt: Date?
+    let usageStatus: String?
+    let usageFrequency: String?
+    let preferenceLevel: String?
 
     nonisolated init(_ perfume: CollectedPerfume) {
         id = perfume.id
@@ -62,6 +65,9 @@ private struct CachedCollectedPerfume: Codable {
         accordStrengths = perfume.accordStrengths.mapValues(\.rawValue)
         memo = perfume.memo
         createdAt = perfume.createdAt
+        usageStatus = perfume.usageStatus?.rawValue
+        usageFrequency = perfume.usageFrequency?.rawValue
+        preferenceLevel = perfume.preferenceLevel?.rawValue
     }
 
     nonisolated var model: CollectedPerfume {
@@ -76,7 +82,10 @@ private struct CachedCollectedPerfume: Codable {
                 result[pair.key] = strength
             },
             memo: memo,
-            createdAt: createdAt
+            createdAt: createdAt,
+            usageStatus: usageStatus.flatMap(CollectedPerfumeUsageStatus.init(rawValue:)),
+            usageFrequency: usageFrequency.flatMap(CollectedPerfumeUsageFrequency.init(rawValue:)),
+            preferenceLevel: preferenceLevel.flatMap(CollectedPerfumePreferenceLevel.init(rawValue:))
         )
     }
 }

--- a/Sniff/Data/Local/LocalPerfumeSearchService.swift
+++ b/Sniff/Data/Local/LocalPerfumeSearchService.swift
@@ -36,10 +36,10 @@ final class LocalPerfumeSearchService {
     // MARK: - 인덱스 로드
 
     /// 앱 시작 후 한 번만 호출 — 디스크 캐시 + Firestore 데이터를 비동기로 인덱싱
-    func buildIndex() {
+    func buildIndex(includesUserData: Bool = true) {
         Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
-            await self.loadIndex()
+            await self.loadIndex(includesUserData: includesUserData)
         }
     }
 
@@ -71,11 +71,7 @@ final class LocalPerfumeSearchService {
         var seenBrands = Set<String>()
         var brandItems: [SuggestionItem] = []
         for item in scored {
-            let brandTokens = item.entry.searchableBrands.map(normalizeForSearch(_:))
-            if brandTokens.contains(where: { token in
-                    // 쿼리가 브랜드명을 포함하거나(token ⊇ query), 쿼리가 브랜드명으로 시작(query.hasPrefix(token))
-                    normalizedQueries.contains(where: { q in token.contains(q) || (q.hasPrefix(token) && token.count >= 2) })
-                }),
+            if normalizedQueries.contains(where: { brandMatchScore(entry: item.entry, query: $0) >= 600 }),
                !seenBrands.contains(item.entry.dedupeBrandKey) {
                 seenBrands.insert(item.entry.dedupeBrandKey)
                 brandItems.append(.brand(name: item.entry.brand, imageUrl: item.entry.imageUrl))
@@ -94,7 +90,7 @@ final class LocalPerfumeSearchService {
 
     // MARK: - Private: 인덱스 구축
 
-    private func loadIndex() async {
+    private func loadIndex(includesUserData: Bool) async {
         var entries: [IndexedEntry] = []
         var seenKeys = Set<String>()
 
@@ -106,21 +102,23 @@ final class LocalPerfumeSearchService {
             entries.append(makeIndexedEntry(name: p.name, brand: p.brand, imageUrl: p.imageUrl))
         }
 
-        // 2. Firestore 보유 향수
-        if let collection = try? await firestoreService.fetchCollection() {
-            for item in collection {
-                let key = dedupeKey(name: item.name, brand: item.brand)
-                guard seenKeys.insert(key).inserted else { continue }
-                entries.append(makeIndexedEntry(name: item.name, brand: item.brand, imageUrl: item.imageUrl))
+        if includesUserData {
+            // 2. Firestore 보유 향수
+            if let collection = try? await firestoreService.fetchCollection() {
+                for item in collection {
+                    let key = dedupeKey(name: item.name, brand: item.brand)
+                    guard seenKeys.insert(key).inserted else { continue }
+                    entries.append(makeIndexedEntry(name: item.name, brand: item.brand, imageUrl: item.imageUrl))
+                }
             }
-        }
 
-        // 3. Firestore LIKE 향수 (LikedPerfume 모델은 imageURL — 대문자)
-        if let liked = try? await firestoreService.fetchLikedPerfumes() {
-            for item in liked {
-                let key = dedupeKey(name: item.name, brand: item.brand)
-                guard seenKeys.insert(key).inserted else { continue }
-                entries.append(makeIndexedEntry(name: item.name, brand: item.brand, imageUrl: item.imageURL))
+            // 3. Firestore LIKE 향수 (LikedPerfume 모델은 imageURL — 대문자)
+            if let liked = try? await firestoreService.fetchLikedPerfumes() {
+                for item in liked {
+                    let key = dedupeKey(name: item.name, brand: item.brand)
+                    guard seenKeys.insert(key).inserted else { continue }
+                    entries.append(makeIndexedEntry(name: item.name, brand: item.brand, imageUrl: item.imageURL))
+                }
             }
         }
 
@@ -150,13 +148,25 @@ final class LocalPerfumeSearchService {
     // MARK: - Private: 매칭 점수
 
     private func matchScore(entry: IndexedEntry, query: String) -> Int {
-        let names = entry.searchableNames.map(normalizeForSearch(_:))
-        let brands = entry.searchableBrands.map(normalizeForSearch(_:))
+        max(
+            brandMatchScore(entry: entry, query: query),
+            nameMatchScore(entry: entry, query: query)
+        )
+    }
 
+    private func brandMatchScore(entry: IndexedEntry, query: String) -> Int {
+        let brands = entry.searchableBrands.map(normalizeForSearch(_:))
         if brands.contains(query) { return 1000 }
-        if names.contains(query) { return 900 }
         if brands.contains(where: { $0.contains(query) }) { return 800 }
+        if brands.contains(where: { isNearTypo($0, query) }) { return 650 }
+        return 0
+    }
+
+    private func nameMatchScore(entry: IndexedEntry, query: String) -> Int {
+        let names = entry.searchableNames.map(normalizeForSearch(_:))
+        if names.contains(query) { return 900 }
         if names.contains(where: { $0.contains(query) }) { return 700 }
+        if names.contains(where: { isNearTypo($0, query) }) { return 600 }
         return 0
     }
 
@@ -183,6 +193,43 @@ final class LocalPerfumeSearchService {
 
     private func dedupeKey(name: String, brand: String) -> String {
         "\(normalizeForSearch(brand))__\(normalizeForSearch(name))"
+    }
+
+    private func isNearTypo(_ lhs: String, _ rhs: String) -> Bool {
+        guard lhs.count >= 2, rhs.count >= 2 else { return false }
+        let lengthGap = abs(lhs.count - rhs.count)
+        guard lengthGap <= 1 else { return false }
+
+        if lhs.count <= 5 || rhs.count <= 5 {
+            return editDistance(lhs, rhs, maxDistance: 1) <= 1
+        }
+        return editDistance(lhs, rhs, maxDistance: 2) <= 2
+    }
+
+    private func editDistance(_ lhs: String, _ rhs: String, maxDistance: Int) -> Int {
+        let lhs = Array(lhs)
+        let rhs = Array(rhs)
+        if abs(lhs.count - rhs.count) > maxDistance { return maxDistance + 1 }
+        if lhs.isEmpty { return rhs.count }
+        if rhs.isEmpty { return lhs.count }
+
+        var previous = Array(0...rhs.count)
+        for i in 1...lhs.count {
+            var current = [i] + Array(repeating: 0, count: rhs.count)
+            var rowMinimum = current[0]
+            for j in 1...rhs.count {
+                let cost = lhs[i - 1] == rhs[j - 1] ? 0 : 1
+                current[j] = min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost
+                )
+                rowMinimum = min(rowMinimum, current[j])
+            }
+            if rowMinimum > maxDistance { return maxDistance + 1 }
+            previous = current
+        }
+        return previous[rhs.count]
     }
 
     private func makeIndexedEntry(name: String, brand: String, imageUrl: String? = nil) -> IndexedEntry {

--- a/Sniff/Data/Local/LocalTastingNoteEntity.swift
+++ b/Sniff/Data/Local/LocalTastingNoteEntity.swift
@@ -21,6 +21,7 @@ final class LocalTastingNoteEntity: NSManagedObject {
     @NSManaged var revisitDesire: String?
     @NSManaged var memo: String
     @NSManaged var perfumeImageURL: String?
+    @NSManaged var usageContext: String?
     @NSManaged var createdAt: Date
     @NSManaged var updatedAt: Date
     @NSManaged var syncStatus: String

--- a/Sniff/Data/Local/LocalTastingNoteRepository.swift
+++ b/Sniff/Data/Local/LocalTastingNoteRepository.swift
@@ -297,6 +297,7 @@ final class LocalTastingNoteRepository {
         entity.revisitDesire = note.revisitDesire
         entity.memo = note.memo
         entity.perfumeImageURL = note.perfumeImageURL
+        entity.usageContext = note.usageContext
         entity.createdAt = note.createdAt
         entity.updatedAt = note.updatedAt
     }
@@ -313,6 +314,7 @@ final class LocalTastingNoteRepository {
             revisitDesire: entity.revisitDesire,
             memo: entity.memo,
             perfumeImageURL: entity.perfumeImageURL,
+            usageContext: entity.usageContext,
             createdAt: entity.createdAt,
             updatedAt: entity.updatedAt
         )

--- a/Sniff/Data/Remote/API/FragellaResponseParser.swift
+++ b/Sniff/Data/Remote/API/FragellaResponseParser.swift
@@ -93,6 +93,10 @@ enum FragellaResponseParser {
                 forKeys: ["popularity", "Popularity", "popularity_score", "rating", "score", "votes"],
                 in: dictionary
             ),
+            releaseYear: yearValue(
+                forKeys: ["release_year", "releaseYear", "year", "launch_year", "launchYear", "launched", "released"],
+                in: dictionary
+            ),
             situation: stringArrayValue(
                 forKeys: ["situation", "situations", "occasion", "occasions"],
                 in: dictionary
@@ -224,6 +228,31 @@ enum FragellaResponseParser {
             }
         }
         return nil
+    }
+
+    private static func yearValue(forKeys keys: [String], in dictionary: [String: Any]) -> Int? {
+        for key in keys {
+            guard let raw = dictionary[key] else { continue }
+            if let number = raw as? NSNumber {
+                let year = number.intValue
+                if isValidReleaseYear(year) { return year }
+            }
+            if let string = raw as? String {
+                let yearCandidates = string.split { !$0.isNumber }
+                for candidate in yearCandidates {
+                    if candidate.count == 4,
+                       let year = Int(String(candidate)),
+                       isValidReleaseYear(year) {
+                        return year
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func isValidReleaseYear(_ year: Int) -> Bool {
+        (1900...Calendar.current.component(.year, from: Date()) + 1).contains(year)
     }
 
     private static func makeSyntheticID(name: String, brand: String) -> String {

--- a/Sniff/Data/Remote/API/GeminiPrompts.swift
+++ b/Sniff/Data/Remote/API/GeminiPrompts.swift
@@ -27,6 +27,11 @@ enum GeminiPrompts {
       - experience: "향수를 처음 시작했어요 | 향수를 가끔씩 뿌려요 | 향수를 꽤 알고 있어요"
       - vibes: ["분위기 태그들 — 앞쪽일수록 사용자가 더 중요하게 여기는 취향"]
       - images: ["향의 느낌 태그들 — 앞쪽일수록 사용자가 더 중요하게 여기는 취향"]
+    - Tag Onboarding Signal (JSON)
+      - seasonMood: 사용자가 고른 계절감/분위기
+      - preferredAndImpressionTags: 사용자가 끌린 향과 주고 싶은 인상 태그들
+      - dislikedScents: 사용자가 싫어한다고 고른 향 태그들
+      - currentPreferredFamilies: 기존 온보딩 분석에서 계산된 선호 계열
     - Aggregated Preference Profile
       - topFamilies: 이미 정렬된 상위 계열 3개
       - topMoods: 이미 정렬된 상위 무드 3개
@@ -36,10 +41,12 @@ enum GeminiPrompts {
 
     입력 해석 우선순위:
     - Aggregated Preference Profile이 있으면 이것을 가장 중요한 주 신호로 사용한다
+    - Tag Onboarding Signal이 있으면 이것을 새 온보딩 형식으로 해석한다
     - Onboarding Signal은 사용자의 원래 취향 출발점을 설명하는 데 사용한다
     - Tasting Records는 보조 증거로만 사용한다
     - record 하나만 보고 전체 취향 방향을 뒤집지 않는다
     - records에서 반복적으로 나타나는 패턴만 강화 신호로 반영한다
+    - dislikedScents는 싫어하는 향이므로 선호 취향으로 해석하지 않는다
 
     분위기 태그 목록:
     세련된, 자연스러운, 신비로운, 활기찬, 여유로운, 청순한, 섹시한, 차분한, 시크한
@@ -50,6 +57,7 @@ enum GeminiPrompts {
     해석 원칙:
     - 분위기 태그와 향의 느낌 태그를 따로 보지 말고 함께 읽는다
     - vibes와 images 배열의 앞쪽 항목일수록 사용자가 더 중요하게 여기는 취향이다
+    - Tag Onboarding Signal이 있으면 preferredAndImpressionTags와 seasonMood를 긍정 신호로 읽고, dislikedScents는 피해야 할 부정 신호로 읽는다
     - 1번째 항목은 가장 강한 신호, 2번째와 3번째 항목은 보조 신호로 해석한다
     - 사용자가 고른 태그의 공통된 흐름을 먼저 파악한다
     - 태그를 단순 나열하지 말고, 어떤 취향으로 읽히는지 자연스럽게 설명한다
@@ -120,8 +128,10 @@ enum GeminiPrompts {
     - 2~4문장으로 작성한다
     - 첫 문장은 전체 취향 인상을 자연스럽게 요약한다
       - 예: "맑고 부드러운 향을 편하게 느끼는 취향이에요"
-    - 둘째 문장까지는 vibes[0]와 images[0]를 가장 중요한 신호로 반영한다
+    - 일반 Onboarding Signal에서는 둘째 문장까지 vibes[0]와 images[0]를 가장 중요한 신호로 반영한다
+    - Tag Onboarding Signal에서는 preferredAndImpressionTags의 앞쪽 항목과 seasonMood를 가장 중요한 긍정 신호로 반영한다
     - 다음 문장에서는 사용자가 고른 태그가 어떻게 함께 읽혔는지 설명한다
+    - dislikedScents는 "좋아하는 느낌"이 아니라 "추천에서 조심할 향"으로만 설명한다
     - 마지막 문장에서는 어떤 향 계열이 잘 어울릴지 자연스럽게 연결한다
     - 어려운 향수 전문용어를 과하게 쓰지 않는다
     - 향 계열은 설명 없이 나열하지 말고, 왜 잘 맞는지 쉬운 말로 연결해서 설명한다
@@ -133,7 +143,8 @@ enum GeminiPrompts {
     - 사용자의 취향을 한 줄로 표현하는 짧은 제목이다
     - 아래 9개 제목 중 하나만 그대로 선택한다
     - 단어를 바꾸거나 새 제목을 만들지 않는다
-    - 사용자의 가장 강한 vibe 1개와 image 1개 조합을 중심으로 가장 가까운 제목을 고른다
+    - 일반 Onboarding Signal에서는 사용자의 가장 강한 vibe 1개와 image 1개 조합을 중심으로 가장 가까운 제목을 고른다
+    - Tag Onboarding Signal에서는 preferredAndImpressionTags, seasonMood, currentPreferredFamilies를 중심으로 가장 가까운 제목을 고른다
     - 애매하면 2번째, 3번째 선택 태그를 보조 신호로 활용한다
     - 허용 제목 목록:
       - 상큼하고 활기찬 취향
@@ -182,7 +193,9 @@ enum GeminiPrompts {
     출력 규칙:
     - 반드시 아래 JSON 구조로만 응답한다
     - JSON 외 설명, 제목, 인삿말, 코드블록 마크다운은 출력하지 않는다
-    - evidence_tags에는 experience, vibes, images만 그대로 반영한다
+    - 일반 Onboarding Signal만 있으면 evidence_tags에는 experience, vibes, images만 그대로 반영한다
+    - Tag Onboarding Signal이 있으면 evidence_tags.experience에는 seasonMood를, evidence_tags.vibes에는 preferredAndImpressionTags를, evidence_tags.images에는 dislikedScents를 반영한다
+    - disliked_tags에는 Tag Onboarding Signal의 dislikedScents를 그대로 유지한다
 
     출력 형식:
     {
@@ -193,6 +206,7 @@ enum GeminiPrompts {
         "vibes": [],
         "images": []
       },
+      "disliked_tags": [],
       "recommendation_direction": {
         "preferred_impression": [],
         "preferred_families": [],

--- a/Sniff/Data/Remote/API/GeminiService.swift
+++ b/Sniff/Data/Remote/API/GeminiService.swift
@@ -96,16 +96,33 @@ final class GeminiTasteAnalysisService {
     }
 
     private func makePromptInput(from input: TasteAnalysisInput) -> String {
-        var sections: [String] = [
-            makeJSONSection(
-                title: "Onboarding Signal (JSON)",
-                value: OnboardingSignalForGemini(
-                    experience: input.experience,
-                    vibes: input.vibes,
-                    images: input.images
+        var sections: [String] = []
+
+        if let tagOnboardingSignal = input.tagOnboardingSignal {
+            sections.append(
+                makeJSONSection(
+                    title: "Tag Onboarding Signal (JSON)",
+                    preface: """
+                    This user completed the newer tag-based onboarding.
+                    preferredAndImpressionTags are positive signals.
+                    dislikedScents are negative signals and must not be interpreted as desired images.
+                    Keep dislikedScents in disliked_tags when producing the response.
+                    """,
+                    value: tagOnboardingSignal
                 )
             )
-        ]
+        } else {
+            sections.append(
+                makeJSONSection(
+                    title: "Onboarding Signal (JSON)",
+                    value: OnboardingSignalForGemini(
+                        experience: input.experience,
+                        vibes: input.vibes,
+                        images: input.images
+                    )
+                )
+            )
+        }
 
         if let aggregatedProfile = input.aggregatedProfile {
             sections.append(

--- a/Sniff/Data/Remote/API/GeminiTasteAnalysisPayloads.swift
+++ b/Sniff/Data/Remote/API/GeminiTasteAnalysisPayloads.swift
@@ -9,6 +9,7 @@ struct TasteAnalysisInput {
     let experience: String
     let vibes: [String]
     let images: [String]
+    let tagOnboardingSignal: TagOnboardingSignalForGemini?
     let aggregatedProfile: AggregatedProfileForGemini?
     let records: [TastingRecordForGemini]
 
@@ -16,14 +17,34 @@ struct TasteAnalysisInput {
         experience: String,
         vibes: [String],
         images: [String],
+        tagOnboardingSignal: TagOnboardingSignalForGemini? = nil,
         aggregatedProfile: AggregatedProfileForGemini? = nil,
         records: [TastingRecordForGemini] = []
     ) {
         self.experience = experience
         self.vibes = vibes
         self.images = images
+        self.tagOnboardingSignal = tagOnboardingSignal
         self.aggregatedProfile = aggregatedProfile
         self.records = records
+    }
+}
+
+struct TagOnboardingSignalForGemini: Codable {
+    let seasonMood: String?
+    let preferredAndImpressionTags: [String]
+    let dislikedScents: [String]
+    let currentPreferredFamilies: [String]
+
+    nonisolated init(analysis: TasteAnalysisResult) {
+        let trimmedExperience = analysis.evidenceTags.experience
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        seasonMood = trimmedExperience.isEmpty ? nil : trimmedExperience
+        preferredAndImpressionTags = analysis.evidenceTags.vibes
+        dislikedScents = analysis.dislikedTags.isEmpty
+            ? analysis.evidenceTags.images
+            : analysis.dislikedTags
+        currentPreferredFamilies = analysis.recommendationDirection.preferredFamilies
     }
 }
 

--- a/Sniff/Data/Remote/Firebase/FirestoreService+VectorParsing.swift
+++ b/Sniff/Data/Remote/Firebase/FirestoreService+VectorParsing.swift
@@ -55,7 +55,10 @@ extension FirestoreService {
             seasonRanking: seasonRanking,
             concentration: data["concentration"] as? String,
             longevity: data["longevity"] as? String,
-            sillage: data["sillage"] as? String
+            sillage: data["sillage"] as? String,
+            usageStatus: CollectedPerfumeUsageStatus(rawValue: data["usageStatus"] as? String ?? ""),
+            usageFrequency: CollectedPerfumeUsageFrequency(rawValue: data["usageFrequency"] as? String ?? ""),
+            preferenceLevel: CollectedPerfumePreferenceLevel(rawValue: data["preferenceLevel"] as? String ?? "")
         )
     }
 

--- a/Sniff/Data/Remote/Firebase/FirestoreService.swift
+++ b/Sniff/Data/Remote/Firebase/FirestoreService.swift
@@ -152,7 +152,7 @@ final class FirestoreService {
         try await ref.updateData(["tasteAnalysis.taste_title": title])
     }
 
-    func fetchTasteProfileHistory(limit: Int = 10) async throws -> [TasteProfileHistoryEntry] {
+    func fetchTasteProfileHistory(limit: Int = 5) async throws -> [TasteProfileHistoryEntry] {
         let snapshot = try await userDocumentRef()
             .collection("profileHistory")
             .order(by: "createdAt", descending: true)
@@ -273,6 +273,29 @@ final class FirestoreService {
         _ perfume: Perfume,
         memo: String? = nil
     ) async throws {
+        try await saveCollectedPerfume(
+            perfume,
+            registrationInfo: nil,
+            memo: memo
+        )
+    }
+
+    func saveCollectedPerfume(
+        _ perfume: Perfume,
+        registrationInfo: CollectedPerfumeRegistrationInfo
+    ) async throws {
+        try await saveCollectedPerfume(
+            perfume,
+            registrationInfo: registrationInfo,
+            memo: registrationInfo.memo
+        )
+    }
+
+    private func saveCollectedPerfume(
+        _ perfume: Perfume,
+        registrationInfo: CollectedPerfumeRegistrationInfo?,
+        memo: String?
+    ) async throws {
         let now = FieldValue.serverTimestamp()
         let ref = try userDocumentRef()
             .collection("collection")
@@ -290,11 +313,26 @@ final class FirestoreService {
             "updatedAt": now
         ]
 
+        if let registrationInfo {
+            data["usageStatus"] = registrationInfo.usageStatus.rawValue
+            data["usageFrequency"] = registrationInfo.usageFrequency.rawValue
+            data["preferenceLevel"] = registrationInfo.preferenceLevel.rawValue
+        }
+
         if let imageUrl = perfume.imageUrl { data["imageUrl"] = imageUrl }
+        if let topNotes = perfume.topNotes, !topNotes.isEmpty { data["topNotes"] = topNotes }
+        if let middleNotes = perfume.middleNotes, !middleNotes.isEmpty { data["middleNotes"] = middleNotes }
+        if let baseNotes = perfume.baseNotes, !baseNotes.isEmpty { data["baseNotes"] = baseNotes }
+        if let generalNotes = perfume.generalNotes, !generalNotes.isEmpty { data["generalNotes"] = generalNotes }
+        if !perfume.seasonRanking.isEmpty {
+            data["seasonRanking"] = perfume.seasonRanking.map { ["name": $0.name, "score": $0.score] }
+        }
         if let concentration = perfume.concentration, !concentration.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             data["concentration"] = concentration
         }
         if let gender = perfume.gender { data["gender"] = gender }
+        if let longevity = perfume.longevity { data["longevity"] = longevity }
+        if let sillage = perfume.sillage { data["sillage"] = sillage }
         if let memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             data["memo"] = memo
         }

--- a/Sniff/Data/Repository/CollectionRepository.swift
+++ b/Sniff/Data/Repository/CollectionRepository.swift
@@ -55,6 +55,25 @@ final class CollectionRepository: CollectionRepositoryType {
     }
 
     func saveCollectedPerfume(_ perfume: Perfume, memo: String? = nil) -> Completable {
+        makeSaveCollectedPerfumeCompletable(perfume, memo: memo, registrationInfo: nil)
+    }
+
+    func saveCollectedPerfume(
+        _ perfume: Perfume,
+        registrationInfo: CollectedPerfumeRegistrationInfo
+    ) -> Completable {
+        makeSaveCollectedPerfumeCompletable(
+            perfume,
+            memo: registrationInfo.memo,
+            registrationInfo: registrationInfo
+        )
+    }
+
+    private func makeSaveCollectedPerfumeCompletable(
+        _ perfume: Perfume,
+        memo: String?,
+        registrationInfo: CollectedPerfumeRegistrationInfo?
+    ) -> Completable {
         Completable.create { [weak self] completable in
             guard let self else {
                 completable(.error(AppSecretsError.missingValue("FIRESTORE_SERVICE")))
@@ -63,7 +82,11 @@ final class CollectionRepository: CollectionRepositoryType {
             let task = Task {
                 do {
                     try self.usageLimiter.validateCollectionChange()
-                    try await self.firestoreService.saveCollectedPerfume(perfume, memo: memo)
+                    if let registrationInfo {
+                        try await self.firestoreService.saveCollectedPerfume(perfume, registrationInfo: registrationInfo)
+                    } else {
+                        try await self.firestoreService.saveCollectedPerfume(perfume, memo: memo)
+                    }
                     self.usageLimiter.recordCollectionChange()
                     self.cacheStore.upsert(
                         CollectedPerfume(
@@ -74,7 +97,18 @@ final class CollectionRepository: CollectionRepositoryType {
                             mainAccords: perfume.mainAccords,
                             accordStrengths: perfume.mainAccordStrengths,
                             memo: memo,
-                            createdAt: Date()
+                            createdAt: Date(),
+                            topNotes: perfume.topNotes,
+                            middleNotes: perfume.middleNotes,
+                            baseNotes: perfume.baseNotes,
+                            generalNotes: perfume.generalNotes,
+                            seasonRanking: perfume.seasonRanking,
+                            concentration: perfume.concentration,
+                            longevity: perfume.longevity,
+                            sillage: perfume.sillage,
+                            usageStatus: registrationInfo?.usageStatus,
+                            usageFrequency: registrationInfo?.usageFrequency,
+                            preferenceLevel: registrationInfo?.preferenceLevel
                         )
                     )
                     completable(.completed)

--- a/Sniff/Data/Repository/UserTasteRepository.swift
+++ b/Sniff/Data/Repository/UserTasteRepository.swift
@@ -165,10 +165,14 @@ final class UserTasteRepository: UserTasteRepositoryType {
             return baseAnalysis
         }
 
+        let isTagOnboarding = user.experienceLevel == "tag_onboarding"
         let enrichedInput = TasteAnalysisInput(
             experience: baseAnalysis.evidenceTags.experience,
             vibes: baseAnalysis.evidenceTags.vibes,
             images: baseAnalysis.evidenceTags.images,
+            tagOnboardingSignal: isTagOnboarding
+                ? TagOnboardingSignalForGemini(analysis: baseAnalysis)
+                : nil,
             aggregatedProfile: (!collectionItems.isEmpty || !recordItems.isEmpty)
                 ? AggregatedProfileForGemini(profile: aggregatedProfile)
                 : nil,
@@ -196,13 +200,6 @@ final class UserTasteRepository: UserTasteRepositoryType {
         )
 
         return refreshedAnalysis
-    }
-
-    func applyHistoricalProfile(_ entry: TasteProfileHistoryEntry) async throws {
-        // Firestore taste_title 업데이트
-        try await firestoreService.applyHistoricalProfile(title: entry.title)
-        // UserDefaults 캐시 초기화 → 다음 fetch 시 Firestore에서 최신 데이터 로드
-        defaults.removeObject(forKey: CacheKey.latestTasteAnalysis)
     }
 
     func checkNicknameAvailability(_ nickname: String) async throws -> Bool {

--- a/Sniff/Domain/Model/CollectedPerfume.swift
+++ b/Sniff/Domain/Model/CollectedPerfume.swift
@@ -7,6 +7,50 @@
 
 import Foundation
 
+enum CollectedPerfumeUsageStatus: String, CaseIterable, Codable {
+    case inUse = "사용중"
+    case unopened = "새상품"
+    case finished = "다 쓴 향수"
+
+    nonisolated var displayName: String { rawValue }
+}
+
+enum CollectedPerfumeUsageFrequency: String, CaseIterable, Codable {
+    case often = "자주"
+    case sometimes = "가끔"
+    case rarely = "거의 안 씀"
+
+    nonisolated var displayName: String { rawValue }
+}
+
+enum CollectedPerfumePreferenceLevel: String, CaseIterable, Codable {
+    case liked = "좋아요"
+    case neutral = "보통"
+    case disappointed = "아쉬워요"
+
+    nonisolated var displayName: String { rawValue }
+}
+
+struct CollectedPerfumeRegistrationInfo: Codable {
+    let usageStatus: CollectedPerfumeUsageStatus
+    let usageFrequency: CollectedPerfumeUsageFrequency
+    let preferenceLevel: CollectedPerfumePreferenceLevel
+    let memo: String?
+
+    nonisolated init(
+        usageStatus: CollectedPerfumeUsageStatus = .inUse,
+        usageFrequency: CollectedPerfumeUsageFrequency = .sometimes,
+        preferenceLevel: CollectedPerfumePreferenceLevel = .liked,
+        memo: String? = nil
+    ) {
+        self.usageStatus = usageStatus
+        self.usageFrequency = usageFrequency
+        self.preferenceLevel = preferenceLevel
+        let trimmedMemo = memo?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.memo = (trimmedMemo?.isEmpty ?? true) ? nil : trimmedMemo
+    }
+}
+
 struct CollectedPerfume {
     let id: String
     let name: String
@@ -24,6 +68,9 @@ struct CollectedPerfume {
     let concentration: String?
     let longevity: String?
     let sillage: String?
+    let usageStatus: CollectedPerfumeUsageStatus?
+    let usageFrequency: CollectedPerfumeUsageFrequency?
+    let preferenceLevel: CollectedPerfumePreferenceLevel?
 
     var scentFamilies: [String] {
         mainAccords.filter { !$0.isEmpty }
@@ -45,7 +92,10 @@ struct CollectedPerfume {
         seasonRanking: [SeasonRankingEntry] = [],
         concentration: String? = nil,
         longevity: String? = nil,
-        sillage: String? = nil
+        sillage: String? = nil,
+        usageStatus: CollectedPerfumeUsageStatus? = nil,
+        usageFrequency: CollectedPerfumeUsageFrequency? = nil,
+        preferenceLevel: CollectedPerfumePreferenceLevel? = nil
     ) {
         self.id = id
         self.name = name
@@ -63,6 +113,9 @@ struct CollectedPerfume {
         self.concentration = concentration
         self.longevity = longevity
         self.sillage = sillage
+        self.usageStatus = usageStatus
+        self.usageFrequency = usageFrequency
+        self.preferenceLevel = preferenceLevel
     }
 
     nonisolated init(

--- a/Sniff/Domain/Model/PreferenceTag.swift
+++ b/Sniff/Domain/Model/PreferenceTag.swift
@@ -13,53 +13,34 @@ enum PreferenceTagCategory {
 }
 
 enum PreferenceTag: String, CaseIterable, Codable {
-    case warm = "따뜻한"
-    case cool = "시원한"
-    case subtle = "은은한"
-    case intense = "강렬한"
-    case fresh = "상큼한"
-    case sweet = "달콤한"
-    case powdery = "보송보송한"
-    case heavy = "묵직한"
-    case light = "가벼운"
-    case clean = "깨끗한"
-    case cozy = "포근한"
     case sophisticated = "세련된"
-    case luxurious = "고급스러운"
     case natural = "자연스러운"
     case mysterious = "신비로운"
     case vibrant = "활기찬"
-    case neutral = "중성적인"
     case relaxed = "여유로운"
+    case pure = "청순한"
+    case sensual = "섹시한"
+    case calm = "차분한"
+    case chic = "시크한"
+    case warm = "따뜻한"
+    case cool = "시원한"
+    case fresh = "상큼한"
+    case sweet = "달콤한"
+    case clean = "깨끗한"
+    case soft = "부드러운"
+    case subtle = "은은한"
+    case clear = "맑은"
+    case deep = "짙은"
 
     nonisolated var displayName: String {
-        switch self {
-        case .warm: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[0]
-        case .cool: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[1]
-        case .subtle: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[2]
-        case .intense: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[3]
-        case .fresh: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[4]
-        case .sweet: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[5]
-        case .powdery: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[6]
-        case .heavy: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[7]
-        case .light: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[8]
-        case .clean: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[9]
-        case .cozy: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[10]
-        case .sophisticated: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[11]
-        case .luxurious: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[12]
-        case .natural: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[13]
-        case .mysterious: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[14]
-        case .vibrant: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[15]
-        case .neutral: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[16]
-        case .relaxed: return AppStrings.DomainDisplay.TastingNoteData.moodTagList[17]
-        }
+        rawValue
     }
 
     var category: PreferenceTagCategory {
         switch self {
-        case .sophisticated, .luxurious, .natural, .mysterious, .vibrant, .neutral, .relaxed:
+        case .sophisticated, .natural, .mysterious, .vibrant, .relaxed, .pure, .sensual, .calm, .chic:
             return .vibe
-        case .warm, .cool, .subtle, .intense, .fresh, .sweet, .powdery, .heavy, .light, .clean, .cozy:
+        case .warm, .cool, .fresh, .sweet, .clean, .soft, .subtle, .clear, .deep:
             return .image
         }
     }
@@ -72,36 +53,36 @@ enum PreferenceTag: String, CaseIterable, Codable {
             return ["aquatic", "fresh", "mint", "eucalyptus", "marine"]
         case .subtle:
             return ["musk", "powdery", "soft floral", "sheer"]
-        case .intense:
-            return ["oud", "leather", "spicy", "incense", "smoky"]
         case .fresh:
             return ["citrus", "fresh", "green", "bergamot", "lemon"]
         case .sweet:
             return ["vanilla", "gourmand", "fruity", "caramel", "honey"]
-        case .powdery:
-            return ["powdery", "iris", "violet", "talc", "soft floral"]
-        case .heavy:
-            return ["oud", "amber", "resinous", "leather", "patchouli"]
-        case .light:
-            return ["fresh", "citrus", "aquatic", "floral", "sheer"]
         case .clean:
             return ["musk", "soap", "aldehyde", "aquatic", "clean"]
-        case .cozy:
-            return ["sandalwood", "vanilla", "soft floral", "musk", "cashmere"]
+        case .soft:
+            return ["musk", "soft floral", "sandalwood", "vanilla", "cashmere"]
+        case .clear:
+            return ["aquatic", "citrus", "herbal", "transparent", "clean"]
+        case .deep:
+            return ["amber", "oud", "woody", "incense", "smoky"]
         case .sophisticated:
             return ["leather", "iris", "aldehyde", "chypre", "rose"]
-        case .luxurious:
-            return ["amber", "oud", "rose", "sandalwood", "resinous"]
         case .natural:
             return ["green", "woody", "earthy", "vetiver", "moss"]
         case .mysterious:
             return ["incense", "oud", "patchouli", "resinous", "dark"]
         case .vibrant:
             return ["citrus", "fruity", "fresh spicy", "aromatic", "energetic"]
-        case .neutral:
-            return ["musk", "woody", "aquatic", "aromatic", "clean"]
         case .relaxed:
             return ["lavender", "woody", "soft musk", "chamomile", "cedar"]
+        case .pure:
+            return ["soft floral", "musk", "aquatic", "clean", "white floral"]
+        case .sensual:
+            return ["amber", "floral amber", "musk", "woody amber", "jasmine"]
+        case .calm:
+            return ["woody", "tea", "soft amber", "lavender", "cedar"]
+        case .chic:
+            return ["dry woods", "woody amber", "iris", "leather", "aromatic"]
         }
     }
 
@@ -113,36 +94,36 @@ enum PreferenceTag: String, CaseIterable, Codable {
             return [.citrus, .green, .water, .aromatic]
         case .subtle:
             return [.softFloral, .floral, .floralAmber]
-        case .intense:
-            return [.dryWoods, .woodyAmber, .amber, .woods]
         case .fresh:
             return [.citrus, .green, .water, .fruity]
         case .sweet:
             return [.softAmber, .amber, .fruity]
-        case .powdery:
-            return [.softFloral, .floralAmber]
-        case .heavy:
-            return [.amber, .woodyAmber, .mossyWoods, .dryWoods]
-        case .light:
-            return [.citrus, .green, .water, .floral]
         case .clean:
             return [.softFloral, .water, .green]
-        case .cozy:
+        case .soft:
             return [.softFloral, .softAmber, .amber]
+        case .clear:
+            return [.water, .citrus, .aromatic]
+        case .deep:
+            return [.amber, .woodyAmber, .dryWoods]
         case .sophisticated:
-            return [.woods, .floralAmber, .dryWoods]
-        case .luxurious:
-            return [.amber, .woodyAmber, .floralAmber, .woods]
+            return [.water, .aromatic, .citrus]
         case .natural:
             return [.green, .woods, .aromatic, .floral]
         case .mysterious:
-            return [.amber, .woodyAmber, .mossyWoods, .dryWoods]
+            return [.water, .amber, .woodyAmber]
         case .vibrant:
             return [.citrus, .fruity, .green, .floral]
-        case .neutral:
-            return [.softFloral, .woods, .aromatic, .water]
         case .relaxed:
             return [.aromatic, .green, .softFloral, .woods]
+        case .pure:
+            return [.softFloral, .floral, .water]
+        case .sensual:
+            return [.amber, .woodyAmber, .floralAmber]
+        case .calm:
+            return [.woods, .softAmber, .aromatic]
+        case .chic:
+            return [.woods, .dryWoods, .woodyAmber]
         }
     }
 
@@ -151,6 +132,6 @@ enum PreferenceTag: String, CaseIterable, Codable {
     }
 
     static var imageTags: [PreferenceTag] {
-        [.warm, .cool, .fresh, .sweet, .clean, .cozy, .intense]
+        [.warm, .cool, .fresh, .sweet, .clean, .soft, .subtle, .clear, .deep]
     }
 }

--- a/Sniff/Domain/Model/perfume.swift
+++ b/Sniff/Domain/Model/perfume.swift
@@ -66,6 +66,7 @@ struct Perfume {
     let season: [String]?
     let seasonRanking: [SeasonRankingEntry]
     let popularity: Double?
+    let releaseYear: Int?
     let situation: [String]?
     let longevity: String?
     let sillage: String?
@@ -89,6 +90,7 @@ struct Perfume {
         season: [String]?,
         seasonRanking: [SeasonRankingEntry] = [],
         popularity: Double? = nil,
+        releaseYear: Int? = nil,
         situation: [String]?,
         longevity: String?,
         sillage: String?
@@ -116,6 +118,7 @@ struct Perfume {
         self.season = season
         self.seasonRanking = seasonRanking
         self.popularity = popularity
+        self.releaseYear = releaseYear
         self.situation = situation
         self.longevity = longevity
         self.sillage = sillage

--- a/Sniff/Domain/Recommendation/PerfumeScorer.swift
+++ b/Sniff/Domain/Recommendation/PerfumeScorer.swift
@@ -49,6 +49,36 @@ struct PerfumeScorer {
         breakdown(perfume: perfume, profile: profile).total
     }
 
+    func tasteMatchScore(
+        perfume: Perfume,
+        profile: UserTasteProfile
+    ) -> Double {
+        let families = ScentFamilyNormalizer.canonicalNames(for: perfume.mainAccords)
+        let rawAccordWeights = families.reduce(into: [String: Double]()) { dict, family in
+            dict[family] = perfume.mainAccordStrengths[family]?.weight
+                ?? AccordStrength.subtle.weight
+        }
+        let accordTotal = rawAccordWeights.values.reduce(0, +)
+        let normalizedAccordWeights: [String: Double] = accordTotal > 0
+            ? rawAccordWeights.mapValues { $0 / accordTotal }
+            : rawAccordWeights
+
+        let accordScore = families.reduce(0.0) { partialResult, family in
+            partialResult + profile.scentVector[family, default: 0] * normalizedAccordWeights[family, default: 0]
+        }
+        let noteVector = NoteToFamilyMapper.noteVector(
+            topNotes: perfume.topNotes,
+            middleNotes: perfume.middleNotes,
+            baseNotes: perfume.baseNotes,
+            generalNotes: perfume.generalNotes
+        )
+        let noteScore = noteVector.reduce(0.0) { partialResult, pair in
+            partialResult + profile.scentVector[pair.key, default: 0] * pair.value
+        }
+
+        return min(1, accordScore + noteScore)
+    }
+
     func breakdown(
         perfume: Perfume,
         profile: UserTasteProfile
@@ -128,16 +158,18 @@ struct PerfumeScorer {
         let preferredScore = min(1, accordScore + noteRawScore)
         let impressionScore = impressionScore(perfume: perfume, profile: profile)
         let seasonScore = seasonScore(perfume: perfume, profile: profile)
-        let koreaTrendScore = min(1.0, Double(PerfumeKoreanTranslator.domesticRetailPriority(for: perfume)) / 100.0)
+        let availabilityScore = min(1.0, Double(PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: perfume)) / 100.0)
+        let recentLaunchScore = recentLaunchScore(perfume: perfume)
         let popularityScore = popularityScore(perfume: perfume)
         let dislikedScore = dislikedScore(perfume: perfume, profile: profile)
 
         let weightedTotal =
             preferredScore * 35
-            + impressionScore * 20
-            + seasonScore * 15
-            + koreaTrendScore * 10
-            + popularityScore * 10
+            + impressionScore * 17
+            + seasonScore * 12
+            + availabilityScore * 18
+            + recentLaunchScore * 12
+            + popularityScore * 6
             - dislikedScore * 45
 
         let total = weightedTotal + intensityBonus
@@ -218,6 +250,29 @@ struct PerfumeScorer {
             return min(1, perfume.seasonRanking.map(\.score).reduce(0, +) / Double(perfume.seasonRanking.count))
         }
         return 0.5
+    }
+
+    private func recentLaunchScore(perfume: Perfume) -> Double {
+        guard let releaseYear = perfume.releaseYear else {
+            return 0.35
+        }
+
+        let currentYear = Calendar.current.component(.year, from: Date())
+        let age = max(0, currentYear - releaseYear)
+        switch age {
+        case 0...1:
+            return 1
+        case 2:
+            return 0.85
+        case 3:
+            return 0.7
+        case 4:
+            return 0.55
+        case 5:
+            return 0.4
+        default:
+            return 0.2
+        }
     }
 
     private func searchableTokens(for perfume: Perfume) -> String {

--- a/Sniff/Domain/Recommendation/PreferenceAggregator.swift
+++ b/Sniff/Domain/Recommendation/PreferenceAggregator.swift
@@ -38,13 +38,13 @@ struct PreferenceAggregator {
         let dislikedOnboardingVec      = OnboardingTagMapper.weightedVector(for: onboarding.dislikedTags)
         let collectionVec              = collectionVector(from: collection)
         let (positiveVec, negativeVec) = tastingVectors(from: tastingRecords)
-        let combinedNegativeVec = normalize(negativeVec.merging(dislikedOnboardingVec) { $0 + $1 })
 
         let scentVector = buildScentVector(
             onboardingVec: onboardingVec,
             collectionVec: collectionVec,
             positiveVec: positiveVec,
-            negativeVec: combinedNegativeVec,
+            dislikedOnboardingVec: dislikedOnboardingVec,
+            negativeTastingVec: negativeVec,
             weights: weights
         )
 
@@ -121,15 +121,60 @@ private extension PreferenceAggregator {
         guard !collection.isEmpty else { return [:] }
 
         var sumVec: [String: Double] = [:]
+        var totalWeight: Double = 0
         for perfume in collection {
+            let ownershipWeight = collectionPreferenceWeight(for: perfume)
+            guard ownershipWeight > 0 else { continue }
             let vec = perfumeVector(from: perfume.accordStrengths, fallback: perfume.mainAccords)
             for (family, value) in vec {
-                sumVec[family, default: 0] += value
+                sumVec[family, default: 0] += value * ownershipWeight
             }
+            totalWeight += ownershipWeight
         }
 
-        let averaged = sumVec.mapValues { $0 / Double(collection.count) }
+        guard totalWeight > 0 else { return [:] }
+        let averaged = sumVec.mapValues { $0 / totalWeight }
         return normalize(averaged)
+    }
+
+    func collectionPreferenceWeight(for perfume: CollectedPerfume) -> Double {
+        let statusWeight: Double
+        switch perfume.usageStatus {
+        case .finished:
+            statusWeight = 1.2
+        case .inUse:
+            statusWeight = 1.0
+        case .unopened:
+            statusWeight = 0.25
+        case nil:
+            statusWeight = 0.8
+        }
+
+        let frequencyWeight: Double
+        switch perfume.usageFrequency {
+        case .often:
+            frequencyWeight = 1.25
+        case .sometimes:
+            frequencyWeight = 0.8
+        case .rarely:
+            frequencyWeight = 0.25
+        case nil:
+            frequencyWeight = 1.0
+        }
+
+        let preferenceWeight: Double
+        switch perfume.preferenceLevel {
+        case .liked:
+            preferenceWeight = 1.2
+        case .neutral:
+            preferenceWeight = 0.5
+        case .disappointed:
+            preferenceWeight = 0.1
+        case nil:
+            preferenceWeight = 1.0
+        }
+
+        return statusWeight * frequencyWeight * preferenceWeight
     }
 
         /// 시향 기록 → 긍정 벡터 + 부정 벡터
@@ -194,15 +239,16 @@ private extension PreferenceAggregator {
 
 private extension PreferenceAggregator {
 
-        /// 소스 벡터들을 가중 합산하고 부정 벡터를 차감
-        /// negativePenalty: 싫어하는 계열을 얼마나 강하게 피할지
+        /// 소스 벡터들을 가중 합산하고 온보딩/시향의 부정 신호를 각각 차감
     func buildScentVector(
         onboardingVec: [String: Double],
         collectionVec: [String: Double],
         positiveVec: [String: Double],
-        negativeVec: [String: Double],
+        dislikedOnboardingVec: [String: Double],
+        negativeTastingVec: [String: Double],
         weights: PreferenceWeights,
-        negativePenalty: Double = 1.5
+        onboardingNegativePenalty: Double = 1.5,
+        tastingNegativePenalty: Double = 1.5
     ) -> [String: Double] {
 
         let positiveKeys = Set(onboardingVec.keys)
@@ -218,8 +264,12 @@ private extension PreferenceAggregator {
             + positiveVec[key, default: 0]   * weights.tasting
         }
 
-        for (key, negValue) in negativeVec {
-            result[key, default: 0] -= negValue * negativePenalty * weights.tasting
+        for (key, negValue) in dislikedOnboardingVec {
+            result[key, default: 0] -= negValue * onboardingNegativePenalty * weights.onboarding
+        }
+
+        for (key, negValue) in negativeTastingVec {
+            result[key, default: 0] -= negValue * tastingNegativePenalty * weights.tasting
         }
 
         result = result.filter { $0.value > 0 }
@@ -320,15 +370,62 @@ private extension PreferenceAggregator {
 
     func mapMoodTagToFamilies(_ tag: String) -> [String] {
         switch tag {
-            case AppStrings.DomainDisplay.TastingNoteData.freshTag: return ["Citrus", "Fruity"]
-            case AppStrings.DomainDisplay.TastingNoteData.coolTag: return ["Water", "Green"]
-            case AppStrings.DomainDisplay.TastingNoteData.airyGreenTag: return ["Green", "Aromatic"]
-            case AppStrings.DomainDisplay.TastingNoteData.subtleTag: return ["Soft Floral", "Floral"]
-            case AppStrings.DomainDisplay.TastingNoteData.powderyTag: return ["Soft Floral", "Soft Amber"]
-            case AppStrings.DomainDisplay.TastingNoteData.warmTag: return ["Soft Amber", "Amber", "Woody Amber"]
-            case AppStrings.DomainDisplay.TastingNoteData.heavyTag: return ["Amber", "Mossy Woods", "Dry Woods"]
-            case AppStrings.DomainDisplay.TastingNoteData.heavierTag: return ["Woody Amber", "Dry Woods"]
-            default:         return []
+            case AppStrings.DomainDisplay.TastingNoteData.sophisticatedTag:
+                return ["Water", "Aromatic", "Citrus"]
+            case AppStrings.DomainDisplay.TastingNoteData.naturalTag:
+                return ["Green", "Mossy Woods", "Aromatic"]
+            case AppStrings.DomainDisplay.TastingNoteData.mysteriousTag:
+                return ["Water", "Amber", "Woody Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.vibrantTag:
+                return ["Citrus", "Fruity", "Green"]
+            case AppStrings.DomainDisplay.TastingNoteData.relaxedTag:
+                return ["Soft Amber", "Soft Floral", "Woods"]
+            case AppStrings.DomainDisplay.TastingNoteData.pureTag:
+                return ["Soft Floral", "Floral", "Water"]
+            case AppStrings.DomainDisplay.TastingNoteData.sensualTag:
+                return ["Amber", "Woody Amber", "Floral Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.calmTag:
+                return ["Woods", "Soft Amber", "Aromatic"]
+            case AppStrings.DomainDisplay.TastingNoteData.chicTag:
+                return ["Woods", "Dry Woods", "Woody Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.warmTag:
+                return ["Soft Amber", "Amber", "Woody Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.coolTag:
+                return ["Water", "Citrus", "Green"]
+            case AppStrings.DomainDisplay.TastingNoteData.freshTag:
+                return ["Citrus", "Fruity"]
+            case AppStrings.DomainDisplay.TastingNoteData.sweetTag:
+                return ["Fruity", "Floral Amber", "Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.cleanTag:
+                return ["Water", "Aromatic", "Soft Floral"]
+            case AppStrings.DomainDisplay.TastingNoteData.softTag:
+                return ["Soft Floral", "Soft Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.subtleTag:
+                return ["Soft Floral", "Floral"]
+            case AppStrings.DomainDisplay.TastingNoteData.clearTag:
+                return ["Water", "Citrus", "Aromatic"]
+            case AppStrings.DomainDisplay.TastingNoteData.deepTag:
+                return ["Amber", "Woody Amber", "Dry Woods"]
+            case AppStrings.DomainDisplay.TastingNoteData.airyGreenTag:
+                return ["Green", "Aromatic"]
+            case AppStrings.DomainDisplay.TastingNoteData.powderyTag:
+                return ["Soft Floral", "Soft Amber"]
+            case AppStrings.DomainDisplay.TastingNoteData.heavyTag:
+                return ["Amber", "Mossy Woods", "Dry Woods"]
+            case AppStrings.DomainDisplay.TastingNoteData.heavierTag:
+                return ["Woody Amber", "Dry Woods"]
+            case "강렬한":
+                return ["Amber", "Dry Woods", "Woody Amber"]
+            case "가벼운":
+                return ["Citrus", "Water", "Floral"]
+            case "포근한":
+                return ["Soft Amber", "Soft Floral"]
+            case "고급스러운":
+                return ["Amber", "Woody Amber", "Floral Amber", "Woods"]
+            case "중성적인":
+                return ["Soft Floral", "Woods", "Aromatic", "Water"]
+            default:
+                return []
         }
     }
 }

--- a/Sniff/Domain/Recommendation/RecommendationEngine+Scoring.swift
+++ b/Sniff/Domain/Recommendation/RecommendationEngine+Scoring.swift
@@ -52,8 +52,8 @@ extension RecommendationEngine {
             return "노트 구성에서 \(family) 무드가 보여 취향과 잘 맞아요"
         }
 
-        if domesticRetailPriority(for: perfume) > 0 {
-            return "국내에서 접하기 쉬운 브랜드라 취향에 맞는 향을 바로 시도해보기 좋아요"
+        if koreaBrandAvailabilityScore(for: perfume) > 0 {
+            return "국내에서 찾기 쉬운 브랜드라 취향에 맞는 향을 시도해보기 좋아요"
         }
 
         if let impression = profile.preferredImpressions.first {
@@ -76,7 +76,7 @@ extension RecommendationEngine {
         return AppStrings.Recommendation.profileFlow(profile.displayTitle)
     }
 
-    private func domesticRetailPriority(for perfume: Perfume) -> Int {
-        PerfumeKoreanTranslator.domesticRetailPriority(for: perfume)
+    private func koreaBrandAvailabilityScore(for perfume: Perfume) -> Int {
+        PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: perfume)
     }
 }

--- a/Sniff/Domain/Recommendation/RecommendationEngine.swift
+++ b/Sniff/Domain/Recommendation/RecommendationEngine.swift
@@ -9,6 +9,10 @@ import Foundation
 import RxSwift
 
 final class RecommendationEngine {
+    private enum ScoringPolicy {
+        static let minimumTasteMatchScore = 0.18
+        static let minimumTasteQualifiedCount = 5
+    }
 
     private let aggregator = PreferenceAggregator()
     private let queryBuilder = RecommendationQueryBuilder()
@@ -34,14 +38,14 @@ final class RecommendationEngine {
         let queries = queryBuilder.buildQueries(from: profile)
         let searchRequests = queries.map {
             perfumeCatalogRepository
-                .search(query: $0, limit: 10)
+                .search(query: $0, limit: 30)
                 .catchAndReturn([])
         }
 
         return Single.zip(searchRequests)
             .map { [weak self] responses in
                 guard let self else {
-                    return RecommendationResult(profile: profile, perfumes: [])
+                    return RecommendationResult(profile: profile, perfumes: [], popularPerfumes: [])
                 }
 
                 let flattenedPerfumes = responses.flatMap { $0 }
@@ -58,12 +62,99 @@ final class RecommendationEngine {
                         }
                         return lhs.score > rhs.score
                     }
+                let tasteQualifiedRecommendations = self.tasteQualifiedRecommendations(
+                    recommendations,
+                    profile: profile
+                )
+
+                let tasteRecommendations = self.limitBrandDuplication(
+                    tasteQualifiedRecommendations,
+                    maxPerBrand: 2,
+                    limit: 10
+                )
+                let visibleTasteIDs = Set(tasteRecommendations.prefix(5).map { self.dedupeKey(for: $0.perfume) })
+                let popularRecommendations = tasteQualifiedRecommendations
+                    .filter { !visibleTasteIDs.contains(self.dedupeKey(for: $0.perfume)) }
+                    .sorted { lhs, rhs in
+                        let lhsScore = self.accessibleTasteScore(lhs, profile: profile)
+                        let rhsScore = self.accessibleTasteScore(rhs, profile: profile)
+                        if lhsScore == rhsScore {
+                            return lhs.perfume.name < rhs.perfume.name
+                        }
+                        return lhsScore > rhsScore
+                    }
 
                 return RecommendationResult(
                     profile: profile,
-                    perfumes: self.limitBrandDuplication(recommendations, maxPerBrand: 2, limit: 10)
+                    perfumes: tasteRecommendations,
+                    popularPerfumes: self.limitBrandDuplication(
+                        popularRecommendations,
+                        maxPerBrand: 2,
+                        limit: 10
+                    )
                 )
             }
+    }
+
+    private func accessibleTasteScore(
+        _ recommendation: RecommendedPerfume,
+        profile: UserTasteProfile
+    ) -> Double {
+        let tasteScore = scorer.tasteMatchScore(perfume: recommendation.perfume, profile: profile)
+        return normalizedAvailability(for: recommendation.perfume) * 45
+            + recentLaunchScore(for: recommendation.perfume) * 35
+            + tasteScore * 15
+            + normalizedPopularity(for: recommendation.perfume) * 5
+    }
+
+    private func tasteQualifiedRecommendations(
+        _ recommendations: [RecommendedPerfume],
+        profile: UserTasteProfile
+    ) -> [RecommendedPerfume] {
+        let qualified = recommendations.filter {
+            scorer.tasteMatchScore(perfume: $0.perfume, profile: profile) >= ScoringPolicy.minimumTasteMatchScore
+        }
+
+        return qualified.count >= ScoringPolicy.minimumTasteQualifiedCount
+            ? qualified
+            : recommendations
+    }
+
+    private func normalizedPopularity(for perfume: Perfume) -> Double {
+        if let popularity = perfume.popularity {
+            if popularity > 100 { return 1 }
+            if popularity > 1 { return min(1, popularity / 100) }
+            return max(0, popularity)
+        }
+
+        return 0
+    }
+
+    private func normalizedAvailability(for perfume: Perfume) -> Double {
+        min(1.0, Double(PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: perfume)) / 100.0)
+    }
+
+    private func recentLaunchScore(for perfume: Perfume) -> Double {
+        guard let releaseYear = perfume.releaseYear else {
+            return 0.35
+        }
+
+        let currentYear = Calendar.current.component(.year, from: Date())
+        let age = max(0, currentYear - releaseYear)
+        switch age {
+        case 0...1:
+            return 1
+        case 2:
+            return 0.85
+        case 3:
+            return 0.7
+        case 4:
+            return 0.55
+        case 5:
+            return 0.4
+        default:
+            return 0.2
+        }
     }
 
     private func limitBrandDuplication(
@@ -83,5 +174,11 @@ final class RecommendationEngine {
         }
 
         return result
+    }
+
+    private func dedupeKey(for perfume: Perfume) -> String {
+        "\(perfume.brand)|\(perfume.name)"
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
     }
 }

--- a/Sniff/Domain/Recommendation/RecommendationModels.swift
+++ b/Sniff/Domain/Recommendation/RecommendationModels.swift
@@ -10,6 +10,7 @@ import Foundation
 struct RecommendationResult {
     let profile: UserTasteProfile
     let perfumes: [RecommendedPerfume]
+    let popularPerfumes: [RecommendedPerfume]
 }
 
 struct RecommendedPerfume {

--- a/Sniff/Domain/Repository/CollectionRepositoryType.swift
+++ b/Sniff/Domain/Repository/CollectionRepositoryType.swift
@@ -13,6 +13,7 @@ protocol CollectionRepositoryType {
     func currentMonthlyCollectionUsage() -> Int
     var monthlyCollectionLimit: Int { get }
     func saveCollectedPerfume(_ perfume: Perfume, memo: String?) -> Completable
+    func saveCollectedPerfume(_ perfume: Perfume, registrationInfo: CollectedPerfumeRegistrationInfo) -> Completable
     func deleteCollectedPerfume(id: String) -> Completable
     func fetchLikedPerfumes() -> Single<[LikedPerfume]>
     func saveLikedPerfume(_ perfume: Perfume) -> Completable

--- a/Sniff/Domain/Repository/UserTasteRepositoryType.swift
+++ b/Sniff/Domain/Repository/UserTasteRepositoryType.swift
@@ -18,7 +18,6 @@ protocol UserTasteRepositoryType {
     ) -> Single<[TasteProfileHistoryEntry]>
     func analyzeTaste(input: TasteAnalysisInput) async throws -> TasteAnalysisResult
     func reanalyzeTasteFromHistory() async throws -> TasteAnalysisResult
-    func applyHistoricalProfile(_ entry: TasteProfileHistoryEntry) async throws
     func checkNicknameAvailability(_ nickname: String) async throws -> Bool
     func saveUserProfile(
         nickname: String,

--- a/Sniff/Localization/PerfumeTranslation/PerfumeKoreanTranslator+Logic.swift
+++ b/Sniff/Localization/PerfumeTranslation/PerfumeKoreanTranslator+Logic.swift
@@ -51,23 +51,31 @@ extension PerfumeKoreanTranslator {
         return normalizedBrandToKorean[normalizeBrandKey(trimmed)] ?? trimmed
     }
 
-    nonisolated static func domesticRetailPriority(for brand: String) -> Int {
+    nonisolated static func koreaBrandAvailabilityScore(for brand: String) -> Int {
         let trimmed = brand.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return 0 }
         if let priority = domesticRetailBrandPriority[trimmed] { return priority }
         return normalizedDomesticRetailBrandPriority[normalizeBrandKey(trimmed)] ?? 0
     }
 
-    nonisolated static func domesticRetailPriority(for perfume: Perfume) -> Int {
+    nonisolated static func koreaBrandAvailabilityScore(for perfume: Perfume) -> Int {
         ([perfume.brand] + perfume.brandAliases)
-            .map { domesticRetailPriority(for: $0) }
+            .map { koreaBrandAvailabilityScore(for: $0) }
             .max() ?? 0
+    }
+
+    nonisolated static func domesticRetailPriority(for brand: String) -> Int {
+        koreaBrandAvailabilityScore(for: brand)
+    }
+
+    nonisolated static func domesticRetailPriority(for perfume: Perfume) -> Int {
+        koreaBrandAvailabilityScore(for: perfume)
     }
 
     nonisolated static func sortedByDomesticRetailPriority(_ perfumes: [Perfume]) -> [Perfume] {
         perfumes.sorted { lhs, rhs in
-            let lhsPriority = domesticRetailPriority(for: lhs)
-            let rhsPriority = domesticRetailPriority(for: rhs)
+            let lhsPriority = koreaBrandAvailabilityScore(for: lhs)
+            let rhsPriority = koreaBrandAvailabilityScore(for: rhs)
             if lhsPriority != rhsPriority { return lhsPriority > rhsPriority }
 
             let lhsBrand = koreanBrand(for: lhs.brand)

--- a/Sniff/Localization/UIStrings/AppStrings+Home.swift
+++ b/Sniff/Localization/UIStrings/AppStrings+Home.swift
@@ -15,6 +15,7 @@ extension AppStrings {
         }
 
         static let recommendTitle = "취향 맞춤 향수"
+        static let popularRecommendTitle = "국내에서 찾기 쉬운 취향 향수"
         static let recommendBasis = "취향 분석 기반 추천이에요"
         static let shortcutPerfume = "향수 등록"
         static let shortcutTasting = "시향기 등록"

--- a/Sniff/Localization/UIStrings/AppStrings+Onboarding.swift
+++ b/Sniff/Localization/UIStrings/AppStrings+Onboarding.swift
@@ -46,7 +46,9 @@ extension AppStrings {
             }
 
             static let subtitle = "나만의 향수를 찾아볼게요"
-            static let cta = "나에게 맞는 향수 보기"
+            static let cta = "홈으로 이동"
+            static let reanalyze = "재분석"
+            static let reanalyzed = "재분석 완료"
             static let footnote = "*보유 향수와 시향기록이 쌓이면 향 계열, 추천 향수, 배경 색상이 함께 업데이트될 수 있습니다."
         }
     }

--- a/Sniff/Localization/UIStrings/AppStrings+TastingNoteData.swift
+++ b/Sniff/Localization/UIStrings/AppStrings+TastingNoteData.swift
@@ -9,9 +9,24 @@ import Foundation
 
 extension AppStrings.DomainDisplay {
     enum TastingNoteData {
+        nonisolated static let sophisticatedTag = "세련된"
+        nonisolated static let naturalTag = "자연스러운"
+        nonisolated static let mysteriousTag = "신비로운"
+        nonisolated static let vibrantTag = "활기찬"
+        nonisolated static let relaxedTag = "여유로운"
+        nonisolated static let pureTag = "청순한"
+        nonisolated static let sensualTag = "섹시한"
+        nonisolated static let calmTag = "차분한"
+        nonisolated static let chicTag = "시크한"
         nonisolated static let freshTag = "상큼한"
         nonisolated static let coolTag = "시원한"
         nonisolated static let subtleTag = "은은한"
+        nonisolated static let sweetTag = "달콤한"
+        nonisolated static let cleanTag = "깨끗한"
+        nonisolated static let softTag = "부드러운"
+        nonisolated static let clearTag = "맑은"
+        nonisolated static let deepTag = "짙은"
+
         nonisolated static let powderyTag = "보송보송한"
         nonisolated static let warmTag = "따뜻한"
         nonisolated static let heavyTag = "묵직한"
@@ -26,11 +41,12 @@ extension AppStrings.DomainDisplay {
         ]
 
         nonisolated static let moodTagList: [String] = [
-            "따뜻한", "시원한", "은은한", "강렬한",
-            "상큼한", "달콤한", "보송보송한", "묵직한",
-            "가벼운", "깨끗한", "포근한", "세련된",
-            "고급스러운", "자연스러운", "신비로운",
-            "활기찬", "중성적인", "여유로운"
+            sophisticatedTag, naturalTag, mysteriousTag,
+            vibrantTag, relaxedTag, pureTag,
+            sensualTag, calmTag, chicTag,
+            warmTag, coolTag, freshTag,
+            sweetTag, cleanTag, softTag,
+            subtleTag, clearTag, deepTag
         ]
 
         nonisolated static func ratingLabel(_ rating: Int) -> String {

--- a/Sniff/Localization/UIStrings/AppStrings+UIKitScreens.swift
+++ b/Sniff/Localization/UIStrings/AppStrings+UIKitScreens.swift
@@ -35,7 +35,7 @@ extension AppStrings {
         enum Search {
             static let placeholder = "향수명 또는 브랜드를 검색하세요"
             static let registerTitle = "향수 등록"
-            static let registerPlaceholder = "향수 이름이나 브랜드를 검색해보세요"
+            static let registerPlaceholder = "향수명만 검색해보세요"
             static let registerConfirmMessage = "이 향수를 내 향수에 등록할까요?"
             static let registerAction = "등록하기"
             static let registerSuccess = "내 향수에 등록했어요"
@@ -80,7 +80,7 @@ extension AppStrings {
             static let imagePlaceholder = "이미지 준비중입니다"
             static let addCollection = "보유향수 등록"
             static let addedCollection = "보유향수 등록됨"
-            static let addTasting = "시향기록 남기기"
+            static let addTasting = "시향 기록 남기기"
             static let tastingSavedTitle = "시향 기록 저장 완료"
 
             static func tastingSaved(_ perfumeName: String) -> String {

--- a/Sniff/Presentation/common/Components/CollectedPerfumeRegistrationViewController.swift
+++ b/Sniff/Presentation/common/Components/CollectedPerfumeRegistrationViewController.swift
@@ -1,0 +1,523 @@
+//
+//  CollectedPerfumeRegistrationViewController.swift
+//  Sniff
+//
+//  Created by Codex on 2026.05.04.
+//
+
+import UIKit
+import Kingfisher
+
+final class CollectedPerfumeRegistrationViewController: UIViewController {
+
+    private enum ContentTab {
+        case perfumeInfo
+        case directInput
+    }
+
+    var onRegister: ((CollectedPerfumeRegistrationInfo) -> Void)?
+    var onRetrySearch: (() -> Void)?
+
+    private let perfume: Perfume
+
+    private let statusControl = UISegmentedControl(items: CollectedPerfumeUsageStatus.allCases.map(\.displayName))
+    private let frequencyControl = UISegmentedControl(items: CollectedPerfumeUsageFrequency.allCases.map(\.displayName))
+    private let preferenceControl = UISegmentedControl(items: CollectedPerfumePreferenceLevel.allCases.map(\.displayName))
+    private let memoTextView = UITextView()
+    private let perfumeImageView = UIImageView()
+    private let perfumeInfoChipButton = UIButton(type: .system)
+    private let directInputChipButton = UIButton(type: .system)
+    private let perfumeInfoContentStack = UIStackView()
+    private let directInputContentStack = UIStackView()
+    private let registerButton = UIButton(type: .system)
+
+    init(perfume: Perfume) {
+        self.perfume = perfume
+        super.init(nibName: nil, bundle: nil)
+        hidesBottomBarWhenPushed = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        title = ""
+
+        statusControl.selectedSegmentIndex = 0
+        frequencyControl.selectedSegmentIndex = 1
+        preferenceControl.selectedSegmentIndex = 0
+        [statusControl, frequencyControl, preferenceControl].forEach(configureSegmentedControl)
+
+        configureContentStacks()
+        configureTabButtons()
+        configureRegisterButton()
+
+        memoTextView.font = .systemFont(ofSize: 15)
+        memoTextView.layer.cornerRadius = 12
+        memoTextView.layer.borderWidth = 1
+        memoTextView.layer.borderColor = UIColor.systemGray5.cgColor
+        memoTextView.textContainerInset = UIEdgeInsets(top: 10, left: 8, bottom: 10, right: 8)
+        memoTextView.heightAnchor.constraint(equalToConstant: 150).isActive = true
+
+        let tabStack = UIStackView(arrangedSubviews: [perfumeInfoChipButton, directInputChipButton])
+        tabStack.axis = .horizontal
+        tabStack.spacing = 8
+        tabStack.distribution = .fillEqually
+        tabStack.heightAnchor.constraint(equalToConstant: 42).isActive = true
+
+        let stack = UIStackView(arrangedSubviews: [
+            makeHeaderView(),
+            makePerfumeCard(),
+            tabStack,
+            perfumeInfoContentStack,
+            directInputContentStack
+        ])
+        stack.axis = .vertical
+        stack.spacing = 22
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let scrollView = UIScrollView()
+        scrollView.alwaysBounceVertical = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stack)
+
+        let bottomContainer = UIView()
+        bottomContainer.backgroundColor = .systemBackground
+        bottomContainer.translatesAutoresizingMaskIntoConstraints = false
+        bottomContainer.addSubview(registerButton)
+        registerButton.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(scrollView)
+        view.addSubview(bottomContainer)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomContainer.topAnchor),
+
+            stack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 24),
+            stack.leadingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.trailingAnchor, constant: -20),
+            stack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -24),
+
+            bottomContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            registerButton.topAnchor.constraint(equalTo: bottomContainer.topAnchor, constant: 12),
+            registerButton.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor, constant: 20),
+            registerButton.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor, constant: -20),
+            registerButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12),
+            registerButton.heightAnchor.constraint(equalToConstant: 54)
+        ])
+
+        configurePerfumeInfoContent()
+        configureDirectInputContent()
+        updateSelectedTab(.directInput)
+    }
+
+    private func makePerfumeCard() -> UIView {
+        let container = UIView()
+        container.backgroundColor = UIColor(hex: "#F7F7FA")
+        container.layer.cornerRadius = 16
+        container.layer.cornerCurve = .continuous
+        container.layer.borderWidth = 1
+        container.layer.borderColor = UIColor.systemGray5.cgColor
+        perfumeImageView.contentMode = .scaleAspectFit
+        perfumeImageView.backgroundColor = .systemBackground
+        perfumeImageView.layer.cornerRadius = 12
+        perfumeImageView.clipsToBounds = true
+        if let imageUrl = perfume.imageUrl, let url = URL(string: imageUrl) {
+            perfumeImageView.kf.setImage(with: url)
+        }
+
+        let brandLabel = UILabel()
+        brandLabel.text = PerfumePresentationSupport.displayBrand(perfume.brand)
+        brandLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        brandLabel.textColor = .secondaryLabel
+
+        let nameLabel = UILabel()
+        nameLabel.text = PerfumePresentationSupport.displayPerfumeName(perfume.name)
+        nameLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+        nameLabel.textColor = .label
+        nameLabel.numberOfLines = 2
+
+        let retryButton = UIButton(type: .system)
+        var retryButtonTitle = AttributedString("다시 검색")
+        retryButtonTitle.font = .systemFont(ofSize: 12, weight: .semibold)
+        var retryConfiguration = UIButton.Configuration.plain()
+        retryConfiguration.attributedTitle = retryButtonTitle
+        retryConfiguration.baseForegroundColor = .label
+        retryConfiguration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
+        retryConfiguration.background.backgroundColor = UIColor(hex: "#F1ECE6")
+        retryConfiguration.background.cornerRadius = 12
+        retryButton.configuration = retryConfiguration
+        retryButton.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
+
+        let labelStack = UIStackView(arrangedSubviews: [brandLabel, nameLabel, retryButton])
+        labelStack.axis = .vertical
+        labelStack.spacing = 4
+        labelStack.alignment = .leading
+
+        [perfumeImageView, labelStack].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview($0)
+        }
+
+        NSLayoutConstraint.activate([
+            perfumeImageView.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            perfumeImageView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            perfumeImageView.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -16),
+            perfumeImageView.widthAnchor.constraint(equalToConstant: 72),
+            perfumeImageView.heightAnchor.constraint(equalToConstant: 88),
+
+            labelStack.leadingAnchor.constraint(equalTo: perfumeImageView.trailingAnchor, constant: 16),
+            labelStack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
+            labelStack.centerYAnchor.constraint(equalTo: perfumeImageView.centerYAnchor)
+        ])
+
+        return container
+    }
+
+    private func makeHeaderView() -> UIView {
+        let container = UIView()
+
+        let backButton = UIButton(type: .system)
+        let configuration = UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
+        backButton.setImage(UIImage(systemName: "chevron.left", withConfiguration: configuration), for: .normal)
+        backButton.tintColor = .label
+        backButton.contentHorizontalAlignment = .leading
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+
+        let titleLabel = UILabel()
+        titleLabel.text = "보유 향수 등록"
+        titleLabel.font = .systemFont(ofSize: 24, weight: .bold)
+        titleLabel.textColor = .label
+        titleLabel.numberOfLines = 1
+
+        [backButton, titleLabel].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview($0)
+        }
+
+        NSLayoutConstraint.activate([
+            backButton.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            backButton.topAnchor.constraint(equalTo: container.topAnchor),
+            backButton.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: 36),
+            backButton.heightAnchor.constraint(equalToConstant: 36),
+
+            titleLabel.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 8),
+            titleLabel.centerYAnchor.constraint(equalTo: backButton.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor)
+        ])
+
+        return container
+    }
+
+    private func configureContentStacks() {
+        [perfumeInfoContentStack, directInputContentStack].forEach {
+            $0.axis = .vertical
+            $0.spacing = 20
+        }
+    }
+
+    private func configureSegmentedControl(_ control: UISegmentedControl) {
+        control.selectedSegmentTintColor = .systemBackground
+        control.backgroundColor = UIColor(hex: "#EFEFF1")
+        control.setTitleTextAttributes([
+            .font: UIFont.systemFont(ofSize: 16, weight: .semibold),
+            .foregroundColor: UIColor.label
+        ], for: .normal)
+        control.setTitleTextAttributes([
+            .font: UIFont.systemFont(ofSize: 16, weight: .semibold),
+            .foregroundColor: UIColor.label
+        ], for: .selected)
+        control.heightAnchor.constraint(equalToConstant: 46).isActive = true
+    }
+
+    private func configureTabButtons() {
+        perfumeInfoChipButton.setTitle("향수 정보", for: .normal)
+        directInputChipButton.setTitle("직접 입력할 정보", for: .normal)
+        perfumeInfoChipButton.addTarget(self, action: #selector(perfumeInfoTabTapped), for: .touchUpInside)
+        directInputChipButton.addTarget(self, action: #selector(directInputTabTapped), for: .touchUpInside)
+    }
+
+    private func configureRegisterButton() {
+        registerButton.setTitle("등록하기", for: .normal)
+        registerButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
+        registerButton.backgroundColor = UIColor(hex: "#1F1F1F")
+        registerButton.setTitleColor(.white, for: .normal)
+        registerButton.layer.cornerRadius = 14
+        registerButton.layer.cornerCurve = .continuous
+        registerButton.addTarget(self, action: #selector(registerTapped), for: .touchUpInside)
+    }
+
+    private func configurePerfumeInfoContent() {
+        perfumeInfoContentStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        perfumeInfoContentStack.addArrangedSubview(makeInfoSection(
+            title: "사용 정보",
+            rows: [
+                ("농도", PerfumePresentationSupport.displayConcentration(perfume.concentration)),
+                ("지속력", PerfumePresentationSupport.displayLongevity(perfume.longevity)),
+                ("확산력", PerfumePresentationSupport.displaySillage(perfume.sillage))
+            ]
+        ))
+
+        perfumeInfoContentStack.addArrangedSubview(makeChipSection(
+            title: "향 계열",
+            values: PerfumePresentationSupport.displayAccords(perfume.mainAccords)
+        ))
+
+        perfumeInfoContentStack.addArrangedSubview(makeInfoSection(
+            title: "노트",
+            rows: [
+                (AppStrings.UIKitScreens.PerfumeDetail.topNotes, joinedNotes(perfume.topNotes)),
+                (AppStrings.UIKitScreens.PerfumeDetail.middleNotes, joinedNotes(perfume.middleNotes)),
+                (AppStrings.UIKitScreens.PerfumeDetail.baseNotes, joinedNotes(perfume.baseNotes))
+            ]
+        ))
+
+        perfumeInfoContentStack.addArrangedSubview(makeChipSection(
+            title: "계절",
+            values: displaySeasons(for: perfume)
+        ))
+    }
+
+    private func configureDirectInputContent() {
+        directInputContentStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        directInputContentStack.addArrangedSubview(makeSectionTitle("직접 입력할 정보"))
+        directInputContentStack.addArrangedSubview(makeField(title: "사용 상태", control: statusControl))
+        directInputContentStack.addArrangedSubview(makeField(title: "사용 빈도", control: frequencyControl))
+        directInputContentStack.addArrangedSubview(makeField(title: "내 취향 정도", control: preferenceControl))
+        directInputContentStack.addArrangedSubview(makeMemoField())
+    }
+
+    private func makeInfoSection(title: String, rows: [(String, String)]) -> UIView {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 12
+
+        stack.addArrangedSubview(makeSectionTitle(title))
+        rows.forEach { title, value in
+            stack.addArrangedSubview(makeInfoRow(title: title, value: value))
+        }
+        return stack
+    }
+
+    private func makeChipSection(title: String, values: [String]) -> UIView {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.addArrangedSubview(makeSectionTitle(title))
+        stack.addArrangedSubview(RegistrationChipWrapView(values: values.isEmpty ? ["-"] : values))
+        return stack
+    }
+
+    private func makeInfoRow(title: String, value: String) -> UIView {
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+        titleLabel.textColor = .secondaryLabel
+        titleLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        let valueLabel = UILabel()
+        valueLabel.text = value
+        valueLabel.font = .systemFont(ofSize: 15, weight: .medium)
+        valueLabel.textColor = .label
+        valueLabel.numberOfLines = 0
+        valueLabel.textAlignment = .right
+
+        let row = UIStackView(arrangedSubviews: [titleLabel, valueLabel])
+        row.axis = .horizontal
+        row.alignment = .firstBaseline
+        row.spacing = 16
+        return row
+    }
+
+    private func makeSectionTitle(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 18, weight: .bold)
+        label.textColor = .label
+        return label
+    }
+
+    private func makeField(title: String, control: UISegmentedControl) -> UIStackView {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 18, weight: .bold)
+        label.textColor = .label
+
+        let stack = UIStackView(arrangedSubviews: [label, control])
+        stack.axis = .vertical
+        stack.spacing = 12
+        return stack
+    }
+
+    private func makeMemoField() -> UIStackView {
+        let label = UILabel()
+        label.text = "메모"
+        label.font = .systemFont(ofSize: 18, weight: .bold)
+        label.textColor = .label
+
+        let stack = UIStackView(arrangedSubviews: [label, memoTextView])
+        stack.axis = .vertical
+        stack.spacing = 12
+        return stack
+    }
+
+    private func joinedNotes(_ notes: [String]?) -> String {
+        let displayNotes = PerfumePresentationSupport.displayNotes(notes ?? [])
+        return displayNotes.isEmpty ? "-" : displayNotes.joined(separator: ", ")
+    }
+
+    private func displaySeasons(for perfume: Perfume) -> [String] {
+        let rankedSeasons = perfume.seasonRanking
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            .prefix(2)
+            .map(\.name)
+        let seasons = rankedSeasons.isEmpty ? (perfume.season ?? []) : Array(rankedSeasons)
+        return PerfumePresentationSupport.displaySeasons(seasons)
+    }
+
+    private func updateSelectedTab(_ tab: ContentTab) {
+        perfumeInfoContentStack.isHidden = tab != .perfumeInfo
+        directInputContentStack.isHidden = tab != .directInput
+        updateChipButton(perfumeInfoChipButton, title: "향수 정보", isSelected: tab == .perfumeInfo)
+        updateChipButton(directInputChipButton, title: "직접 입력할 정보", isSelected: tab == .directInput)
+    }
+
+    private func updateChipButton(_ button: UIButton, title: String, isSelected: Bool) {
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = title
+        configuration.baseForegroundColor = isSelected ? .white : .label
+        configuration.baseBackgroundColor = isSelected ? UIColor(hex: "#1F1F1F") : UIColor(hex: "#F3F3F5")
+        configuration.cornerStyle = .capsule
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
+        button.configuration = configuration
+    }
+
+    @objc private func perfumeInfoTabTapped() {
+        updateSelectedTab(.perfumeInfo)
+    }
+
+    @objc private func directInputTabTapped() {
+        updateSelectedTab(.directInput)
+    }
+
+    @objc private func retryTapped() {
+        navigationController?.popViewController(animated: true)
+        onRetrySearch?()
+    }
+
+    @objc private func backTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    @objc private func registerTapped() {
+        let status = CollectedPerfumeUsageStatus.allCases[statusControl.selectedSegmentIndex]
+        let frequency = CollectedPerfumeUsageFrequency.allCases[frequencyControl.selectedSegmentIndex]
+        let preference = CollectedPerfumePreferenceLevel.allCases[preferenceControl.selectedSegmentIndex]
+        let info = CollectedPerfumeRegistrationInfo(
+            usageStatus: status,
+            usageFrequency: frequency,
+            preferenceLevel: preference,
+            memo: memoTextView.text
+        )
+        onRegister?(info)
+    }
+}
+
+private final class RegistrationChipWrapView: UIView {
+    private let values: [String]
+    private var chipViews: [UILabel] = []
+
+    init(values: [String]) {
+        self.values = values
+        super.init(frame: .zero)
+        setupChips()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupChips() {
+        chipViews = values.map { value in
+            let label = UILabel()
+            label.text = value
+            label.font = .systemFont(ofSize: 14, weight: .semibold)
+            label.textColor = .label
+            label.backgroundColor = UIColor(hex: "#F3F3F5")
+            label.layer.cornerRadius = 16
+            label.layer.masksToBounds = true
+            label.textAlignment = .center
+            label.numberOfLines = 1
+            label.lineBreakMode = .byTruncatingTail
+            addSubview(label)
+            return label
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let horizontalSpacing: CGFloat = 8
+        let verticalSpacing: CGFloat = 8
+        let horizontalPadding: CGFloat = 16
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        chipViews.forEach { label in
+            let textWidth = label.sizeThatFits(
+                CGSize(width: bounds.width, height: 34)
+            ).width
+            let chipWidth = min(max(textWidth + horizontalPadding * 2, 48), bounds.width)
+            if x > 0, x + chipWidth > bounds.width {
+                x = 0
+                y += rowHeight + verticalSpacing
+                rowHeight = 0
+            }
+            label.frame = CGRect(x: x, y: y, width: chipWidth, height: 34)
+            x += chipWidth + horizontalSpacing
+            rowHeight = max(rowHeight, 34)
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let availableWidth = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width - 40
+        let horizontalSpacing: CGFloat = 8
+        let verticalSpacing: CGFloat = 8
+        let horizontalPadding: CGFloat = 16
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        let rowHeight: CGFloat = 34
+
+        chipViews.forEach { label in
+            let textWidth = label.sizeThatFits(
+                CGSize(width: availableWidth, height: 34)
+            ).width
+            let chipWidth = min(max(textWidth + horizontalPadding * 2, 48), availableWidth)
+            if x > 0, x + chipWidth > availableWidth {
+                x = 0
+                y += rowHeight + verticalSpacing
+            }
+            x += chipWidth + horizontalSpacing
+        }
+
+        return CGSize(width: UIView.noIntrinsicMetric, height: y + rowHeight)
+    }
+}

--- a/Sniff/Presentation/common/Components/PerfumeGridCardView.swift
+++ b/Sniff/Presentation/common/Components/PerfumeGridCardView.swift
@@ -35,7 +35,7 @@ enum PerfumeCardStyle: Equatable {
     var imagePadding: CGFloat {
         switch self {
         case .preview:
-            return 4
+            return 0
         case .grid:
             return 4
         case .listThumbnail:
@@ -182,7 +182,7 @@ enum PerfumeCardStyle: Equatable {
     var artworkWidthRatio: CGFloat {
         switch self {
         case .preview:
-            return 0.9
+            return 1.0
         case .grid:
             return 0.86
         case .listThumbnail:
@@ -193,7 +193,7 @@ enum PerfumeCardStyle: Equatable {
     var artworkHeightRatio: CGFloat {
         switch self {
         case .preview:
-            return 0.9
+            return 1.0
         case .grid:
             return 0.88
         case .listThumbnail:

--- a/Sniff/Presentation/common/Tab/Home/ViewControllers/HomeViewController.swift
+++ b/Sniff/Presentation/common/Tab/Home/ViewControllers/HomeViewController.swift
@@ -65,6 +65,7 @@ final class HomeViewController: UIViewController {
     private let disposeBag = DisposeBag()
     private let homeRefreshRelay = PublishRelay<Void>()
     private var recommendations: [HomePerfumeItem] = []
+    private var popularRecommendations: [HomePerfumeItem] = []
     private var currentProfileItem: HomeViewModel.HomeProfileItem?
     private var currentBannerItem: HomeTasteBannerItem?
     private var likedPerfumeIDs = Set<String>()
@@ -155,6 +156,24 @@ button.setPreferredSymbolConfiguration(
     }()
 
     private let recommendationCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = Layout.cardSpacing
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsHorizontalScrollIndicator = false
+        return collectionView
+    }()
+
+    private let popularRecommendationTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = AppStrings.Home.popularRecommendTitle
+        label.font = Typography.pretendard(size: 18, weight: .semibold)
+        label.textColor = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha: 1)
+        return label
+    }()
+
+    private let popularRecommendationCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = Layout.cardSpacing
@@ -263,6 +282,12 @@ private extension HomeViewController {
             HomePerfumeCardCell.self,
             forCellWithReuseIdentifier: HomePerfumeCardCell.reuseIdentifier
         )
+        popularRecommendationCollectionView.delegate = self
+        popularRecommendationCollectionView.dataSource = self
+        popularRecommendationCollectionView.register(
+            HomePerfumeCardCell.self,
+            forCellWithReuseIdentifier: HomePerfumeCardCell.reuseIdentifier
+        )
 
         view.addSubview(scrollView)
         scrollView.contentInsetAdjustmentBehavior = .never  // 상태바 영역까지 그라데이션 확장
@@ -276,6 +301,8 @@ private extension HomeViewController {
             profileHeroCard,
             recommendationTitleLabel,
             recommendationCollectionView,
+            popularRecommendationTitleLabel,
+            popularRecommendationCollectionView,
             guideContainerView
         ].forEach { contentView.addSubview($0) }
 
@@ -367,8 +394,19 @@ private extension HomeViewController {
             $0.height.equalTo(Layout.cardHeight)
         }
 
+        popularRecommendationTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(recommendationCollectionView.snp.bottom).offset(28)
+            $0.leading.equalToSuperview().offset(16)
+        }
+
+        popularRecommendationCollectionView.snp.makeConstraints {
+            $0.top.equalTo(popularRecommendationTitleLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(Layout.cardHeight)
+        }
+
         guideContainerView.snp.makeConstraints {
-            $0.top.equalTo(recommendationCollectionView.snp.bottom).offset(34)  // Figma: 34pt gap
+            $0.top.equalTo(popularRecommendationCollectionView.snp.bottom).offset(34)  // Figma: 34pt gap
             $0.leading.trailing.equalToSuperview().inset(16)  // Figma: 16pt 좌우 여백 → 358pt 너비
             $0.bottom.equalToSuperview().inset(20)
         }
@@ -441,6 +479,7 @@ private extension HomeViewController {
         bindBanner(output.banner)
         bindProfile(output.profile)
         bindRecommendations(output.recommendations)
+        bindPopularRecommendations(output.popularRecommendations)
         bindRoute(output.route)
         bindAddPerfumeButton()
     }
@@ -487,6 +526,17 @@ private extension HomeViewController {
             .drive(with: self) { owner, items in
                 owner.recommendations = items
                 owner.recommendationCollectionView.reloadData()
+            }
+            .disposed(by: disposeBag)
+    }
+
+    func bindPopularRecommendations(_ recommendations: Driver<[HomePerfumeItem]>) {
+        recommendations
+            .drive(with: self) { owner, items in
+                owner.popularRecommendations = items
+                owner.popularRecommendationTitleLabel.isHidden = items.isEmpty
+                owner.popularRecommendationCollectionView.isHidden = items.isEmpty
+                owner.popularRecommendationCollectionView.reloadData()
             }
             .disposed(by: disposeBag)
     }
@@ -632,7 +682,7 @@ private extension HomeViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] items in
                 self?.likedPerfumeIDs = Set(items.map(\.id))
-                self?.recommendationCollectionView.reloadData()
+                self?.reloadRecommendationCollections()
             })
             .disposed(by: disposeBag)
     }
@@ -646,7 +696,7 @@ private extension HomeViewController {
                     brandName: $0.brandName
                 )
             })
-            recommendationCollectionView.reloadData()
+            reloadRecommendationCollections()
         }
 
         // 2단계: Firestore에서 추가 병합 (비동기) — 다른 기기 기록까지 포함
@@ -661,7 +711,7 @@ private extension HomeViewController {
                     )
                 })
                 self.tastingNoteKeys.formUnion(remoteKeys)
-                self.recommendationCollectionView.reloadData()
+                self.reloadRecommendationCollections()
             }, onFailure: { _ in })
             .disposed(by: disposeBag)
     }
@@ -690,7 +740,7 @@ private extension HomeViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onCompleted: { [weak self] in
                 self?.likedPerfumeIDs.insert(collectionID)
-                self?.recommendationCollectionView.reloadData()
+                self?.reloadRecommendationCollections()
                 NotificationCenter.default.post(name: .perfumeCollectionDidChange, object: nil)
             }, onError: { [weak self] error in
                 self?.presentLikeMutationError(error)
@@ -703,7 +753,7 @@ private extension HomeViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onCompleted: { [weak self] in
                 self?.likedPerfumeIDs.remove(id)
-                self?.recommendationCollectionView.reloadData()
+                self?.reloadRecommendationCollections()
                 NotificationCenter.default.post(name: .perfumeCollectionDidChange, object: nil)
             }, onError: { [weak self] error in
                 self?.presentLikeMutationError(error)
@@ -722,11 +772,26 @@ private extension HomeViewController {
     var visibleRecommendations: [HomePerfumeItem] {
         Array(recommendations.prefix(5))
     }
+
+    var visiblePopularRecommendations: [HomePerfumeItem] {
+        Array(popularRecommendations.prefix(5))
+    }
+
+    func visibleItems(for collectionView: UICollectionView) -> [HomePerfumeItem] {
+        collectionView == popularRecommendationCollectionView
+            ? visiblePopularRecommendations
+            : visibleRecommendations
+    }
+
+    func reloadRecommendationCollections() {
+        recommendationCollectionView.reloadData()
+        popularRecommendationCollectionView.reloadData()
+    }
 }
 
 extension HomeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        visibleRecommendations.count
+        visibleItems(for: collectionView).count
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -737,7 +802,7 @@ extension HomeViewController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
 
-        let item = visibleRecommendations[indexPath.item]
+        let item = visibleItems(for: collectionView)[indexPath.item]
         let collectionID = Perfume.collectionDocumentID(from: item.id)
         let hasTastingRecord = !tastingNoteKeys.isDisjoint(
             with: PerfumePresentationSupport.recordMatchingKeys(
@@ -782,7 +847,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        navigateToPerfumeDetail(visibleRecommendations[indexPath.item].perfume)
+        navigateToPerfumeDetail(visibleItems(for: collectionView)[indexPath.item].perfume)
     }
 }
 

--- a/Sniff/Presentation/common/Tab/Home/ViewControllers/TasteProfileColorInfoViewController.swift
+++ b/Sniff/Presentation/common/Tab/Home/ViewControllers/TasteProfileColorInfoViewController.swift
@@ -32,7 +32,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
         // 2. 맑고 세련된 취향
         .init(
             title: "맑고 세련된 취향",
-            subtitle: "워터 · 아로마틱 중심",
+            subtitle: "워터 · 아로마틱 · 시트러스 중심",
             gradientColors: [
                 UIColor(red: 0.97, green: 0.94, blue: 0.80, alpha: 1),
                 UIColor(red: 0.73, green: 0.87, blue: 0.92, alpha: 1),
@@ -54,7 +54,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
         // 4. 부드럽고 청순한 취향
         .init(
             title: "부드럽고 청순한 취향",
-            subtitle: "소프트 플로럴 · 플로럴 중심",
+            subtitle: "소프트 플로럴 · 플로럴 · 워터 중심",
             gradientColors: [
                 UIColor(red: 1.00, green: 0.56, blue: 0.53, alpha: 1),
                 UIColor(red: 0.94, green: 0.66, blue: 0.72, alpha: 1),
@@ -65,7 +65,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
         // 5. 포근하고 여유로운 취향
         .init(
             title: "포근하고 여유로운 취향",
-            subtitle: "소프트 앰버 · 소프트 플로럴 중심",
+            subtitle: "소프트 앰버 · 소프트 플로럴 · 우디 중심",
             gradientColors: [
                 UIColor(red: 0.94, green: 0.66, blue: 0.72, alpha: 1),
                 UIColor(red: 0.82, green: 0.45, blue: 0.67, alpha: 1),
@@ -76,7 +76,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
         // 6. 달콤하고 화사한 취향
         .init(
             title: "달콤하고 화사한 취향",
-            subtitle: "프루티 · 플로럴 앰버 중심",
+            subtitle: "프루티 · 플로럴 앰버 · 앰버 중심",
             gradientColors: [
                 UIColor(red: 0.94, green: 0.48, blue: 0.75, alpha: 1),
                 UIColor(red: 1.00, green: 0.67, blue: 0.49, alpha: 1),
@@ -87,7 +87,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
         // 7. 싱그럽고 자연스러운 취향
         .init(
             title: "싱그럽고 자연스러운 취향",
-            subtitle: "그린 · 워터 중심",
+            subtitle: "그린 · 모시 우즈 · 워터 중심",
             gradientColors: [
                 UIColor(red: 0.60, green: 0.81, blue: 0.89, alpha: 1),
                 UIColor(red: 0.74, green: 0.87, blue: 0.66, alpha: 1),
@@ -98,7 +98,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
         // 8. 짙고 시크한 취향
         .init(
             title: "짙고 시크한 취향",
-            subtitle: "우디 · 드라이 우즈 중심",
+            subtitle: "우디 · 드라이 우즈 · 우디 앰버 중심",
             gradientColors: [
                 UIColor(red: 0.75, green: 0.74, blue: 0.65, alpha: 1),
                 UIColor(red: 0.84, green: 0.73, blue: 0.59, alpha: 1),
@@ -156,7 +156,7 @@ final class TasteProfileColorInfoViewController: UIViewController {
 
     // 두 번째 설명 레이블 (첫 번째와 8pt 간격)
     private let desc2Label = UILabel().then {
-        $0.text = "*취향 프로필은 보유 향수와 시향기록이 쌓여지는 것에 따라 취향 프로필이 변경될 수 있습니다."
+        $0.text = "*취향 프로필은 보유 향수와 시향기록이 쌓여지는 것에 따라 변경될 수 있습니다. 같은 취향 프로필 안에서도 중심 향 계열은 달라질 수 있으며, 색상은 취향 프로필 기준으로 유지될 수 있습니다."
         $0.font = .systemFont(ofSize: 15, weight: .medium)
         $0.textColor = TasteProfileColorInfoViewController.neutral700
         $0.numberOfLines = 0

--- a/Sniff/Presentation/common/Tab/Home/ViewControllers/TasteProfileViewController.swift
+++ b/Sniff/Presentation/common/Tab/Home/ViewControllers/TasteProfileViewController.swift
@@ -120,8 +120,10 @@ final class TasteProfileViewController: UIViewController {
 
     // 현재 적용 중인 히스토리 entry ID (가장 최신)
     private var currentEntryId: String?
-    // 히스토리 항목 캐시 (탭 시 entry 조회용)
-    private var cachedEntries: [TasteProfileHistoryEntry] = []
+    private var historyEntries: [TasteProfileHistoryEntry] = []
+    private var isHistoryExpanded = false
+    private let collapsedHistoryCount = 2
+    private let maxVisibleHistoryCount = 5
 
     // MARK: - Init
 
@@ -311,24 +313,44 @@ private extension TasteProfileViewController {
             ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
         }
         currentEntryId = sorted.first?.id
-        cachedEntries = sorted  // entry 탭 시 조회를 위해 캐싱
+        historyEntries = Array(sorted.prefix(maxVisibleHistoryCount))
+        isHistoryExpanded = false
+
+        renderHistoryRows()
+    }
+
+    func renderHistoryRows() {
+        let visibleEntries = isHistoryExpanded
+            ? historyEntries
+            : Array(historyEntries.prefix(collapsedHistoryCount))
 
         // 기존 뷰 초기화
         historyStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        sorted.enumerated().forEach { index, entry in
+        visibleEntries.enumerated().forEach { index, entry in
             let isCurrent = entry.id == currentEntryId
             let row = makeHistoryRow(entry: entry, isCurrent: isCurrent)
             historyStackView.addArrangedSubview(row)
 
             // 구분선 (마지막 항목 제외)
-            if index < sorted.count - 1 {
-                let divider = UIView()
-                divider.backgroundColor = UIColor(red: 0.93, green: 0.93, blue: 0.93, alpha: 1)
-                historyStackView.addArrangedSubview(divider)
-                divider.snp.makeConstraints { $0.height.equalTo(1) }
+            if index < visibleEntries.count - 1 {
+                historyStackView.addArrangedSubview(makeHistoryDivider())
             }
         }
+
+        if historyEntries.count > collapsedHistoryCount {
+            if !visibleEntries.isEmpty {
+                historyStackView.addArrangedSubview(makeHistoryDivider())
+            }
+            historyStackView.addArrangedSubview(makeHistoryToggleRow())
+        }
+    }
+
+    func makeHistoryDivider() -> UIView {
+        let divider = UIView()
+        divider.backgroundColor = UIColor(red: 0.93, green: 0.93, blue: 0.93, alpha: 1)
+        divider.snp.makeConstraints { $0.height.equalTo(1) }
+        return divider
     }
 
     func makeHistoryRow(entry: TasteProfileHistoryEntry, isCurrent: Bool) -> UIView {
@@ -406,73 +428,30 @@ private extension TasteProfileViewController {
             $0.bottom.equalToSuperview().inset(14)
         }
 
-        // 현재 적용 중이 아닌 항목만 탭 가능
-        if !isCurrent {
-            let tap = UITapGestureRecognizer(target: self, action: #selector(historyRowTapped(_:)))
-            container.addGestureRecognizer(tap)
-            container.accessibilityIdentifier = entry.id
-            container.isUserInteractionEnabled = true
-        }
-
         return container
     }
 
-    @objc func historyRowTapped(_ gesture: UITapGestureRecognizer) {
-        guard let container = gesture.view,
-              let entryId = container.accessibilityIdentifier else { return }
-
-        // 해당 entry 찾기
-        guard let entry = findEntry(byId: entryId) else { return }
-
-        applyProfile(entry: entry)
+    func makeHistoryToggleRow() -> UIView {
+        let button = UIButton(type: .system)
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = isHistoryExpanded ? "접기" : "더보기"
+        configuration.image = UIImage(systemName: isHistoryExpanded ? "chevron.down" : "chevron.up")
+        configuration.imagePlacement = .trailing
+        configuration.imagePadding = 6
+        configuration.baseForegroundColor = UIColor(red: 0.39, green: 0.39, blue: 0.39, alpha: 1)
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
+        button.configuration = configuration
+        button.titleLabel?.font = UIFont(name: "Pretendard-Medium", size: 14)
+            ?? .systemFont(ofSize: 14, weight: .medium)
+        button.addTarget(self, action: #selector(historyToggleTapped), for: .touchUpInside)
+        return button
     }
 
-    private func findEntry(byId id: String) -> TasteProfileHistoryEntry? {
-        // historyStackView의 arranged subviews에서 entry 찾기
-        for view in historyStackView.arrangedSubviews {
-            if view.accessibilityIdentifier == id {
-                // entry 정보는 accessibilityLabel에 저장
-                // 대신 entry를 캐싱하는 방식 사용
-            }
-        }
-        return cachedEntries.first { $0.id == id }
-    }
-
-    func applyProfile(entry: TasteProfileHistoryEntry) {
-        // 로딩 인디케이터
-        let alert = UIAlertController(title: nil, message: "취향 프로필을 변경하는 중...", preferredStyle: .alert)
-        let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
-        loadingIndicator.hidesWhenStopped = true
-        loadingIndicator.style = .medium
-        loadingIndicator.startAnimating()
-        alert.view.addSubview(loadingIndicator)
-        present(alert, animated: true)
-
-        Task {
-            do {
-                try await userTasteRepository.applyHistoricalProfile(entry)
-
-                // 홈 화면과 마이페이지에 프로필 변경 알림
-                NotificationCenter.default.post(
-                    name: .tasteProfileDidChange,
-                    object: nil,
-                    userInfo: [
-                        "title": entry.title,
-                        "families": entry.families
-                    ]
-                )
-
-                await MainActor.run {
-                    alert.dismiss(animated: true) { [weak self] in
-                        self?.navigationController?.popViewController(animated: true)
-                    }
-                }
-            } catch {
-                await MainActor.run {
-                    alert.dismiss(animated: true)
-                    print("[TasteProfile] 프로필 적용 실패:", error)
-                }
-            }
+    @objc func historyToggleTapped() {
+        isHistoryExpanded.toggle()
+        UIView.performWithoutAnimation {
+            renderHistoryRows()
+            view.layoutIfNeeded()
         }
     }
 }

--- a/Sniff/Presentation/common/Tab/Home/ViewModels/HomeViewModel.swift
+++ b/Sniff/Presentation/common/Tab/Home/ViewModels/HomeViewModel.swift
@@ -31,6 +31,7 @@ final class HomeViewModel {
         let banner: Driver<HomeTasteBannerItem>
         let quickActions: Driver<[HomeQuickAction]>
         let recommendations: Driver<[HomePerfumeItem]>
+        let popularRecommendations: Driver<[HomePerfumeItem]>
         let profile: Driver<HomeProfileItem?>
         let route: Signal<HomeRoute>
     }
@@ -152,6 +153,31 @@ final class HomeViewModel {
             })
             .asDriver(onErrorJustReturn: [])
 
+        let popularRecommendations = recommendationResult
+            .withLatestFrom(sourceData) { ($0, $1) }
+            .map { payload -> [HomePerfumeItem] in
+                let (result, source) = payload
+                guard let result, let source else {
+                    return []
+                }
+                let tastingKeys = Set(
+                    source.tastingRecords.map {
+                        PerfumePresentationSupport.recordKey(
+                            perfumeName: $0.perfumeName,
+                            brandName: $0.brandName
+                        )
+                    }
+                )
+                return result.popularPerfumes.map { recommendation in
+                    mapToHomePerfumeItem(
+                        recommendation,
+                        profile: result.profile,
+                        tastingKeys: tastingKeys
+                    )
+                }
+            }
+            .asDriver(onErrorJustReturn: [])
+
         input.perfumeRegisterTap
             .map { HomeRoute.perfumeRegister }
             .bind(to: routeRelay)
@@ -180,6 +206,7 @@ final class HomeViewModel {
             banner: banner,
             quickActions: quickActions,
             recommendations: recommendations,
+            popularRecommendations: popularRecommendations,
             profile: profile,
             route: routeRelay.asSignal()
         )

--- a/Sniff/Presentation/common/Tab/MainTabView.swift
+++ b/Sniff/Presentation/common/Tab/MainTabView.swift
@@ -25,20 +25,42 @@ final class MainTabRouter: ObservableObject {
     static let shared = MainTabRouter()
 
     @Published var selectedTab: MainTabSelection = .home
+    @Published private var resetTokens: [MainTabSelection: UUID] = [:]
 
     private init() {}
 
     func select(_ tab: MainTabSelection) {
+        selectAndReset(tab)
+    }
+
+    func selectAndReset(_ tab: MainTabSelection) {
         selectedTab = tab
+        reset(tab)
+    }
+
+    func reset(_ tab: MainTabSelection) {
+        resetTokens[tab] = UUID()
+    }
+
+    func resetToken(for tab: MainTabSelection) -> UUID {
+        resetTokens[tab] ?? UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
     }
 }
 
 struct MainTabView: View {
     @ObservedObject private var tabRouter = MainTabRouter.shared
 
+    private var selectedTabBinding: Binding<MainTabSelection> {
+        Binding(
+            get: { tabRouter.selectedTab },
+            set: { tabRouter.selectAndReset($0) }
+        )
+    }
+
     var body: some View {
-        TabView(selection: $tabRouter.selectedTab) {
+        TabView(selection: selectedTabBinding) {
             HomeTabContainerView()
+                .id(tabRouter.resetToken(for: .home))
                 .ignoresSafeArea(.all, edges: .top)  // 상태바 영역까지 그라데이션 확장
                 .tabItem {
                     Image(systemName: "house")
@@ -47,6 +69,7 @@ struct MainTabView: View {
                 .tag(MainTabSelection.home)
 
             SearchTabContainerView()
+                .id(tabRouter.resetToken(for: .search))
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text(AppStrings.AppShell.MainTab.search)
@@ -54,6 +77,7 @@ struct MainTabView: View {
                 .tag(MainTabSelection.search)
 
             TastingNoteSceneFactory.makeListView()
+                .id(tabRouter.resetToken(for: .tastingNote))
                 .tabItem {
                     Image(systemName: "book.closed.fill")
                     Text(AppStrings.AppShell.MainTab.tastingNote)
@@ -61,6 +85,7 @@ struct MainTabView: View {
                 .tag(MainTabSelection.tastingNote)
 
             MyTabContainerView()
+                .id(tabRouter.resetToken(for: .my))
                 .tabItem {
                     Image(systemName: "person.circle")
                     Text(AppStrings.AppShell.MainTab.my)
@@ -68,6 +93,71 @@ struct MainTabView: View {
                 .tag(MainTabSelection.my)
         }
         .tint(.black)
+        .background(MainTabResetObserver())
+    }
+}
+
+private struct MainTabResetObserver: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = UIViewController()
+        DispatchQueue.main.async {
+            context.coordinator.attachIfNeeded(from: viewController)
+        }
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        DispatchQueue.main.async {
+            context.coordinator.attachIfNeeded(from: uiViewController)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, UITabBarControllerDelegate {
+        private weak var tabBarController: UITabBarController?
+
+        func attachIfNeeded(from viewController: UIViewController) {
+            guard let tabBarController = findTabBarController(from: viewController),
+                  self.tabBarController !== tabBarController else { return }
+            self.tabBarController = tabBarController
+            tabBarController.delegate = self
+        }
+
+        func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+            guard let index = tabBarController.viewControllers?.firstIndex(of: viewController),
+                  let tab = MainTabSelection(rawValue: index) else { return }
+            MainTabRouter.shared.selectAndReset(tab)
+        }
+
+        private func findTabBarController(from viewController: UIViewController) -> UITabBarController? {
+            var current: UIViewController? = viewController
+            while let candidate = current {
+                if let tabBarController = candidate as? UITabBarController {
+                    return tabBarController
+                }
+                current = candidate.parent
+            }
+            guard let rootViewController = viewController.view.window?.rootViewController else { return nil }
+            return findTabBarController(in: rootViewController)
+        }
+
+        private func findTabBarController(in viewController: UIViewController) -> UITabBarController? {
+            if let tabBarController = viewController as? UITabBarController {
+                return tabBarController
+            }
+            for child in viewController.children {
+                if let tabBarController = findTabBarController(in: child) {
+                    return tabBarController
+                }
+            }
+            if let presentedViewController = viewController.presentedViewController {
+                return findTabBarController(in: presentedViewController)
+            }
+            return nil
+        }
     }
 }
 

--- a/Sniff/Presentation/common/Tab/MyPage/Views/MyPageView.swift
+++ b/Sniff/Presentation/common/Tab/MyPage/Views/MyPageView.swift
@@ -16,18 +16,18 @@ struct MyPageView: View {
     private enum Layout {
         static let horizontalPadding: CGFloat = 16
         static let headerTopPadding: CGFloat = 18
-        static let sectionSpacing: CGFloat = 36
-        static let sectionContentSpacing: CGFloat = 10
-        static let sectionHeaderBottomSpacing: CGFloat = 4
+        static let sectionSpacing: CGFloat = 18
+        static let sectionContentSpacing: CGFloat = 6
+        static let sectionHeaderBottomSpacing: CGFloat = 0
         static let profileTopSpacing: CGFloat = -14.5
-        static let profileBottomSpacing: CGFloat = 8
+        static let profileBottomSpacing: CGFloat = 2
         static let profileImageSize: CGFloat = 60
         static let profileTextSpacing: CGFloat = 6
         static let profileTasteTopSpacing: CGFloat = 8
         static let tasteIconSize: CGFloat = 18
-        static let cardSpacing: CGFloat = 16
+        static let cardSpacing: CGFloat = 6
         static let trailingPeekInset: CGFloat = PerfumeGridCardLayout.previewTrailingPeekInset
-        static let likedSectionTopSpacing: CGFloat = 2
+        static let likedSectionTopSpacing: CGFloat = 0
         static let bottomContentPadding: CGFloat = 68
 
         static var cardWidth: CGFloat {

--- a/Sniff/Presentation/common/Tab/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Sniff/Presentation/common/Tab/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -40,6 +40,8 @@ final class OnboardingViewModel: ObservableObject {
     @Published var errorMessage: String? = nil
     @Published var nickname: String = ""
     @Published private(set) var nicknameValidationState: NicknameValidationState = .idle
+    @Published private(set) var canReanalyzeResult: Bool = true
+    private var isReanalyzingResult = false
 
     private let nicknameValidator = NicknameValidator()
     private let userTasteRepository: UserTasteRepositoryType
@@ -132,7 +134,18 @@ final class OnboardingViewModel: ObservableObject {
 
     func finishOnboardingQuestions() async {
         guard canProceedFromImpressions else { return }
-        await saveTagOnboarding()
+        let didSave = await saveTagOnboarding()
+        if didSave && isReanalyzingResult {
+            canReanalyzeResult = false
+            isReanalyzingResult = false
+        }
+    }
+
+    func beginResultReanalysis() {
+        guard canReanalyzeResult, !isLoading, currentStep == .result else { return }
+        isReanalyzingResult = true
+        errorMessage = nil
+        currentStep = .dislikedScents
     }
 
     func clearNickname() {
@@ -350,7 +363,8 @@ final class OnboardingViewModel: ObservableObject {
         )
     }
 
-    private func saveTagOnboarding() async {
+    @discardableResult
+    private func saveTagOnboarding(failureStep: OnboardingStep = .impression) async -> Bool {
         isLoading = true
         errorMessage = nil
         currentStep = .loadingResult
@@ -365,9 +379,11 @@ final class OnboardingViewModel: ObservableObject {
             )
             tasteResult = result
             currentStep = .result
+            return true
         } catch {
-            currentStep = .impression
+            currentStep = failureStep
             errorMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/Sniff/Presentation/common/Tab/Onboarding/Views/OnboardingResultView.swift
+++ b/Sniff/Presentation/common/Tab/Onboarding/Views/OnboardingResultView.swift
@@ -131,16 +131,35 @@ struct OnboardingResultView: View {
             Divider()
                 .background(Color(hex: "#EEF0F3"))
 
-            Button {
-                onComplete()
-            } label: {
-                Text(AppStrings.Onboarding.Result.cta)
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 54)
-                    .background(Color(hex: "#F1E8DF"))
-                    .foregroundColor(.black)
-                    .cornerRadius(12)
+            HStack(spacing: 10) {
+                Button {
+                    viewModel.beginResultReanalysis()
+                } label: {
+                    Text(viewModel.canReanalyzeResult ? AppStrings.Onboarding.Result.reanalyze : AppStrings.Onboarding.Result.reanalyzed)
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 54)
+                        .background(viewModel.canReanalyzeResult ? Color.white : Color(hex: "#E2E5EA"))
+                        .foregroundColor(viewModel.canReanalyzeResult ? .black : Color(hex: "#9EA6B5"))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(hex: "#D8DCE3"), lineWidth: 1)
+                        )
+                        .cornerRadius(12)
+                }
+                .disabled(!viewModel.canReanalyzeResult || viewModel.isLoading)
+
+                Button {
+                    onComplete()
+                } label: {
+                    Text(AppStrings.Onboarding.Result.cta)
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 54)
+                        .background(Color(hex: "#F1E8DF"))
+                        .foregroundColor(.black)
+                        .cornerRadius(12)
+                }
             }
             .padding(.horizontal, horizontalInset)
             .padding(.top, 18)

--- a/Sniff/Presentation/common/Tab/PerfumeDetail/ViewControllers/PerfumeDetailView.swift
+++ b/Sniff/Presentation/common/Tab/PerfumeDetail/ViewControllers/PerfumeDetailView.swift
@@ -39,7 +39,6 @@ final class PerfumeDetailViewController: UIViewController {
     private var bottomBarCenterYConstraint: Constraint?
     private weak var bottomBarHostView: UIView?
 
-    private let addCollectionRelay = PublishRelay<Void>()
     private let addTastingRecordRelay = PublishRelay<Void>()
 
     init(
@@ -121,14 +120,6 @@ final class PerfumeDetailViewController: UIViewController {
     private let accordListView = ScentFamilyListView()
     private let notesView = DetailNotesView()
     private let seasonChipsView = SeasonSelectionView()
-
-    private let addCollectionButton = UIButton(type: .system).then {
-        $0.setTitle(AppStrings.UIKitScreens.PerfumeDetail.addCollection, for: .normal)
-        $0.titleLabel?.font = .systemFont(ofSize: 15, weight: .medium)
-        $0.setTitleColor(Palette.textSecondary, for: .normal)
-        $0.backgroundColor = UIColor(hex: "#F6F6F8")
-        $0.layer.cornerRadius = 12
-    }
 
     private let addTastingButton = UIButton(type: .system).then {
         $0.setTitle(AppStrings.UIKitScreens.PerfumeDetail.addTasting, for: .normal)
@@ -226,7 +217,7 @@ final class PerfumeDetailViewController: UIViewController {
         accordsSectionView.embed(accordListView)
         notesSectionView.embed(notesView)
         seasonSectionView.embed(seasonChipsView)
-        [addCollectionButton, addTastingButton].forEach { bottomBarView.addSubview($0) }
+        bottomBarView.addSubview(addTastingButton)
 
         topBarView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
@@ -320,18 +311,11 @@ final class PerfumeDetailViewController: UIViewController {
             $0.bottom.equalToSuperview().offset(-40)
         }
 
-        addCollectionButton.snp.makeConstraints {
+        addTastingButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().offset(-20)
             $0.top.bottom.equalToSuperview().inset(5)
             $0.height.equalTo(48)
-        }
-
-        addTastingButton.snp.makeConstraints {
-            $0.leading.equalTo(addCollectionButton.snp.trailing).offset(12)
-            $0.trailing.equalToSuperview().offset(-20)
-            $0.centerY.equalTo(addCollectionButton)
-            $0.height.equalTo(addCollectionButton)
-            $0.width.equalTo(addCollectionButton)
         }
 
         backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
@@ -341,7 +325,7 @@ final class PerfumeDetailViewController: UIViewController {
     private func bind() {
         let input = PerfumeDetailViewModel.Input(
             viewDidLoad: Observable.just(()),
-            addToCollectionTap: addCollectionRelay.asObservable(),
+            addToCollectionTap: .empty(),
             addTastingRecordTap: addTastingRecordRelay.asObservable()
         )
 
@@ -367,22 +351,11 @@ final class PerfumeDetailViewController: UIViewController {
             })
             .disposed(by: disposeBag)
 
-        output.onAddToCollection
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] _ in
-                self?.toggleOwnedCollection()
-            })
-            .disposed(by: disposeBag)
-
         output.onAddTastingRecord
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] perfume in
                 self?.navigateToTastingRecord(perfume: perfume)
             })
-            .disposed(by: disposeBag)
-
-        addCollectionButton.rx.tap
-            .bind(to: addCollectionRelay)
             .disposed(by: disposeBag)
 
         addTastingButton.rx.tap
@@ -430,7 +403,6 @@ final class PerfumeDetailViewController: UIViewController {
         seasonChipsView.configure(selectedSeasons: topSeasonNames(for: perfume))
         let collectionID = perfume.collectionDocumentID
         updateLikeUI(isLiked: likedPerfumeIDs.contains(collectionID))
-        updateOwnedUI(isOwned: ownedPerfumeIDs.contains(collectionID))
         updateTastingButtonUI()
     }
 
@@ -559,7 +531,10 @@ final class PerfumeDetailViewController: UIViewController {
     }
 
     private func navigateToTastingRecord(perfume: Perfume) {
-        let formView = TastingNoteSceneFactory.makeFormView(initialPerfume: perfume) { [weak self] perfumeName in
+        let formView = TastingNoteSceneFactory.makeFormView(
+            initialPerfume: perfume,
+            isOwnedPerfumeContext: ownedPerfumeIDs.contains(perfume.collectionDocumentID)
+        ) { [weak self] perfumeName in
             guard let self else { return }
             self.hasTastingRecord = true
             self.updateTastingButtonUI()
@@ -622,7 +597,7 @@ final class PerfumeDetailViewController: UIViewController {
 
         container.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(addCollectionButton.snp.top).offset(-12)
+            $0.bottom.equalTo(addTastingButton.snp.top).offset(-12)
         }
 
         container.alpha = 0
@@ -681,9 +656,6 @@ final class PerfumeDetailViewController: UIViewController {
                 onSuccess: { [weak self] items in
                     guard let self else { return }
                     self.ownedPerfumeIDs = Set(items.map(\.id))
-                    if let perfume = self.currentPerfume {
-                        self.updateOwnedUI(isOwned: self.ownedPerfumeIDs.contains(perfume.collectionDocumentID))
-                    }
                 },
                 onFailure: { error in
                     print("[PerfumeDetail] fetchCollection failed: \(error)")
@@ -736,58 +708,8 @@ final class PerfumeDetailViewController: UIViewController {
         updateLikeUI(isLiked: isLiked)
     }
 
-    private func toggleOwnedCollection() {
-        guard let perfume = currentPerfume else { return }
-
-        let collectionID = perfume.collectionDocumentID
-        let wasOwned = ownedPerfumeIDs.contains(collectionID)
-        updateOwnedState(for: collectionID, isOwned: !wasOwned)
-        addCollectionButton.isEnabled = false
-
-        if wasOwned {
-            collectionRepository.deleteCollectedPerfume(id: collectionID)
-                .observe(on: MainScheduler.instance)
-                .subscribe(onCompleted: { [weak self] in
-                    self?.addCollectionButton.isEnabled = true
-                    self?.notifyCollectionChanged()
-                }, onError: { [weak self] error in
-                    self?.addCollectionButton.isEnabled = true
-                    self?.updateOwnedState(for: collectionID, isOwned: wasOwned)
-                    self?.presentMutationError(error)
-                })
-                .disposed(by: disposeBag)
-        } else {
-            collectionRepository.saveCollectedPerfume(perfume, memo: nil)
-                .observe(on: MainScheduler.instance)
-                .subscribe(onCompleted: { [weak self] in
-                    self?.addCollectionButton.isEnabled = true
-                    self?.notifyCollectionChanged()
-                    self?.navigateToMyPage()
-                }, onError: { [weak self] error in
-                    self?.addCollectionButton.isEnabled = true
-                    self?.updateOwnedState(for: collectionID, isOwned: wasOwned)
-                    self?.presentMutationError(error)
-                })
-                .disposed(by: disposeBag)
-        }
-    }
-
-    private func updateOwnedState(for perfumeID: String, isOwned: Bool) {
-        if isOwned {
-            ownedPerfumeIDs.insert(perfumeID)
-        } else {
-            ownedPerfumeIDs.remove(perfumeID)
-        }
-        updateOwnedUI(isOwned: isOwned)
-    }
-
     private func updateLikeUI(isLiked: Bool) {
         PerfumeHeartStyle.applyState(to: likeButton, isLiked: isLiked)
-    }
-
-    private func updateOwnedUI(isOwned: Bool) {
-        let title = isOwned ? AppStrings.UIKitScreens.PerfumeDetail.addedCollection : AppStrings.UIKitScreens.PerfumeDetail.addCollection
-        addCollectionButton.setTitle(title, for: .normal)
     }
 
     private func refreshTastingRecordState() {
@@ -813,8 +735,7 @@ final class PerfumeDetailViewController: UIViewController {
     }
 
     private func updateTastingButtonUI() {
-        let title = hasTastingRecord ? "시향기로 이동" : AppStrings.UIKitScreens.PerfumeDetail.addTasting
-        addTastingButton.setTitle(title, for: .normal)
+        addTastingButton.setTitle(AppStrings.UIKitScreens.PerfumeDetail.addTasting, for: .normal)
     }
 
     private func presentMutationError(_ error: Error) {

--- a/Sniff/Presentation/common/Tab/Search/Services/SearchFilterEngine.swift
+++ b/Sniff/Presentation/common/Tab/Search/Services/SearchFilterEngine.swift
@@ -110,7 +110,9 @@ enum SearchFilterEngine {
     }
 
     nonisolated private static func seasonTokens(for perfume: Perfume) -> Set<String> {
-        let explicitSeasons = (perfume.season ?? []) + perfume.seasonRanking.map(\.name)
+        let explicitSeasons = topSeasonRankingNames(for: perfume)
+            ?? perfume.season
+            ?? []
         var tokens = Set(
             explicitSeasons.flatMap { seasonValue in
                 normalizedSeasonTokens(for: seasonValue)
@@ -122,6 +124,18 @@ enum SearchFilterEngine {
         }
 
         return tokens
+    }
+
+    nonisolated private static func topSeasonRankingNames(for perfume: Perfume) -> [String]? {
+        let names = perfume.seasonRanking
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            .prefix(2)
+            .map(\.name)
+
+        return names.isEmpty ? nil : Array(names)
     }
 
     nonisolated private static func inferredSeasonTokens(for perfume: Perfume) -> Set<String> {

--- a/Sniff/Presentation/common/Tab/Search/ViewControllers/FilterViewController.swift
+++ b/Sniff/Presentation/common/Tab/Search/ViewControllers/FilterViewController.swift
@@ -375,7 +375,7 @@ final class FilterViewController: UIViewController {
             ),
             .init(
                 title: AppStrings.UIKitScreens.Filter.season,
-                subtitle: nil,
+                subtitle: "최대 1개 선택 가능",
                 tags: Season.allCases.map(\.displayName),
                 type: .season,
                 topInset: 15,

--- a/Sniff/Presentation/common/Tab/Search/ViewControllers/SearchViewController.swift
+++ b/Sniff/Presentation/common/Tab/Search/ViewControllers/SearchViewController.swift
@@ -97,6 +97,7 @@ final class SearchViewController: UIViewController {
     private var tastingNoteKeys = Set<String>()
     private var hasHandledRecentOnAppear = false
     private var isRegisteringCollection = false
+    private var pendingRegisterSuggestion: (name: String, brand: String)?
     private weak var presentedTastingFormController: UIViewController?
 
     // MARK: - 자동저장 상태
@@ -223,6 +224,7 @@ private let sortButton = UIButton(type: .system).then {
         $0.register(RecentSearchCell.self, forCellReuseIdentifier: RecentSearchCell.identifier)
         $0.register(SuggestionCell.self, forCellReuseIdentifier: SuggestionCell.identifier)
         $0.register(SearchMessageCell.self, forCellReuseIdentifier: SearchMessageCell.identifier)
+        $0.register(PerfumeSearchResultCell.self, forCellReuseIdentifier: PerfumeSearchResultCell.identifier)
         $0.separatorStyle = .none
         $0.rowHeight = UITableView.automaticDimension
         $0.estimatedRowHeight = 68
@@ -371,7 +373,7 @@ private let sortButton = UIButton(type: .system).then {
         self.localTastingNoteRepository = localTastingNoteRepository
         self.showsRecentOnAppear = showsRecentOnAppear
         self.mode = mode
-        self.currentState = showsRecentOnAppear ? .initial : .landing
+        self.currentState = showsRecentOnAppear && mode != .register ? .initial : .landing
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -795,7 +797,9 @@ private extension SearchViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] items in
                 guard let self else { return }
-                self.suggestions = items
+                self.suggestions = self.mode == .register
+                    ? self.registrationSuggestionItems(from: items)
+                    : items
                 if case .suggesting = self.currentState {
                     self.reloadTableView()
                 }
@@ -833,9 +837,12 @@ private extension SearchViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] perfumes in
                 guard let self else { return }
-                self.filteredPerfumeResults = perfumes
+                self.filteredPerfumeResults = self.mode == .register
+                    ? self.registrationPerfumeNameResults(from: perfumes)
+                    : perfumes
                 self.reloadPerfumeResults()
                 self.updateResultVisibility()
+                self.openPendingRegisterSuggestionIfPossible()
             })
             .disposed(by: disposeBag)
     }
@@ -886,18 +893,15 @@ private extension SearchViewController {
 
         searchBar.rx.searchButtonClicked
             .withLatestFrom(searchTextRelay)
-            .bind(to: searchTriggerRelay)
+            .subscribe(onNext: { [weak self] text in
+                self?.submitSearchQuery(text)
+            })
             .disposed(by: disposeBag)
 
         searchSubmitButton.rx.tap
             .withLatestFrom(searchTextRelay)
             .subscribe(onNext: { [weak self] text in
-                let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmedText.isEmpty {
-                    self?.searchBar.becomeFirstResponder()
-                } else {
-                    self?.searchTriggerRelay.accept(trimmedText)
-                }
+                self?.submitSearchQuery(text)
             })
             .disposed(by: disposeBag)
 
@@ -907,6 +911,7 @@ private extension SearchViewController {
                 self.searchBar.text = nil
                 self.searchTextRelay.accept("")
                 self.updateSearchBarAccessory(for: "")
+                self.pendingRegisterSuggestion = nil
                 self.clearTriggerRelay.accept(())
                 self.searchBar.becomeFirstResponder()
             })
@@ -915,13 +920,17 @@ private extension SearchViewController {
         searchBar.rx.textDidBeginEditing
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
+                self.pendingRegisterSuggestion = nil
                 self.currentState = .initial
                 self.updateLayout(for: .initial)
             })
             .disposed(by: disposeBag)
 
         searchBar.rx.cancelButtonClicked
-            .bind(to: clearTriggerRelay)
+            .subscribe(onNext: { [weak self] in
+                self?.pendingRegisterSuggestion = nil
+                self?.clearTriggerRelay.accept(())
+            })
             .disposed(by: disposeBag)
     }
 
@@ -1077,6 +1086,10 @@ private extension SearchViewController {
     }
 
     func showInitialLayout() {
+        if mode == .register {
+            showLandingLayout()
+            return
+        }
         tableView.isHidden = false
         resultHeaderView.isHidden = true
         landingGuideLabel.isHidden = true
@@ -1131,6 +1144,11 @@ private extension SearchViewController {
     }
 
     func showLandingLayout() {
+        if mode == .register {
+            showRegisterEmptyLayout()
+            return
+        }
+
         tableView.isHidden = true
         resultHeaderView.isHidden = false
         landingGuideLabel.isHidden = true
@@ -1151,6 +1169,24 @@ private extension SearchViewController {
         resultHeaderTopToGuideConstraint?.deactivate()
         resultHeaderTopToBrandEmptyConstraint?.activate()
         tableView.tableFooterView = nil
+        applyKeyboardInset()
+    }
+
+    func showRegisterEmptyLayout() {
+        tableView.isHidden = true
+        resultHeaderView.isHidden = true
+        landingGuideLabel.isHidden = true
+        brandSectionLabel.isHidden = true
+        brandTableView.isHidden = true
+        brandEmptyLabel.isHidden = true
+        perfumeCollectionView.isHidden = true
+        emptyView.isHidden = false
+        backButton.isHidden = (navigationController?.viewControllers.count ?? 0) <= 1
+        updateSearchBarLeadingConstraint()
+        searchBar.showsCancelButton = false
+        tableView.tableHeaderView = nil
+        tableView.tableFooterView = nil
+        emptyView.configureLanding()
         applyKeyboardInset()
     }
 
@@ -1181,7 +1217,170 @@ private extension SearchViewController {
     }
 
     func reloadPerfumeResults() {
-        perfumeCollectionView.reloadData()
+        if mode == .register {
+            tableView.reloadData()
+        } else {
+            perfumeCollectionView.reloadData()
+        }
+    }
+
+    func submitSearchQuery(_ text: String) {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            searchBar.becomeFirstResponder()
+            return
+        }
+
+        guard mode != .register || hasRegistrationPerfumeNameCandidate(for: trimmedText) else {
+            showAppToast(message: "향수명으로 검색해 주세요")
+            searchBar.becomeFirstResponder()
+            return
+        }
+
+        pendingRegisterSuggestion = nil
+        searchTriggerRelay.accept(trimmedText)
+    }
+
+    func hasRegistrationPerfumeNameCandidate(for query: String) -> Bool {
+        suggestions.contains { item in
+            guard case let .perfume(name, _, _) = item else { return false }
+            return registrationNameScore(name: name, query: query) > 0
+        }
+    }
+
+    func registrationPerfumeNameResults(from perfumes: [Perfume]) -> [Perfume] {
+        guard case let .result(query) = currentState else {
+            return Array(perfumes.prefix(3))
+        }
+
+        return perfumes
+            .map { perfume in (perfume: perfume, score: registrationNameScore(for: perfume, query: query)) }
+            .filter { $0.score > 0 }
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                let lhsPriority = PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: lhs.perfume)
+                let rhsPriority = PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: rhs.perfume)
+                if lhsPriority != rhsPriority { return lhsPriority > rhsPriority }
+                return lhs.perfume.name.localizedCaseInsensitiveCompare(rhs.perfume.name) == .orderedAscending
+            }
+            .prefix(3)
+            .map(\.perfume)
+    }
+
+    func registrationSuggestionItems(from items: [SuggestionItem]) -> [SuggestionItem] {
+        let query = searchTextRelay.value
+        return items
+            .filter { item in
+                guard case let .perfume(name, _, _) = item else { return false }
+                return registrationNameScore(name: name, query: query) > 0
+            }
+            .prefix(3)
+            .map { $0 }
+    }
+
+    func registrationNameScore(for perfume: Perfume, query: String) -> Int {
+        let queryCandidates = registrationSearchQueryCandidates(for: query)
+        guard !queryCandidates.isEmpty else { return 0 }
+
+        let nameValues = registrationSearchableNameValues(for: perfume)
+            .map(registrationNormalizeForSearch(_:))
+
+        for query in queryCandidates {
+            if nameValues.contains(query) { return 1_000 }
+            if nameValues.contains(where: { $0.hasPrefix(query) }) { return 900 }
+            if nameValues.contains(where: { $0.contains(query) }) { return 800 }
+            if nameValues.contains(where: { query.contains($0) && $0.count >= 2 }) { return 700 }
+        }
+        return 0
+    }
+
+    func registrationNameScore(name: String, query: String) -> Int {
+        let queryCandidates = registrationSearchQueryCandidates(for: query)
+        guard !queryCandidates.isEmpty else { return 0 }
+
+        let nameValues = [name, PerfumePresentationSupport.displayPerfumeName(name)]
+            .map(registrationNormalizeForSearch(_:))
+            .filter { !$0.isEmpty }
+
+        for query in queryCandidates {
+            if nameValues.contains(query) { return 1_000 }
+            if nameValues.contains(where: { $0.hasPrefix(query) }) { return 900 }
+            if nameValues.contains(where: { $0.contains(query) }) { return 800 }
+            if nameValues.contains(where: { query.contains($0) && $0.count >= 2 }) { return 700 }
+        }
+        return 0
+    }
+
+    func registrationSearchQueryCandidates(for query: String) -> [String] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidates = [trimmed, PerfumeKoreanTranslator.toEnglishQuery(trimmed)]
+            .compactMap { $0 }
+            .map(registrationNormalizeForSearch(_:))
+            .filter { !$0.isEmpty }
+
+        var seen = Set<String>()
+        return candidates.filter { seen.insert($0).inserted }
+    }
+
+    func registrationSearchableNameValues(for perfume: Perfume) -> [String] {
+        let values = [perfume.name, PerfumePresentationSupport.displayPerfumeName(perfume.name)] + perfume.nameAliases
+        var seen = Set<String>()
+        return values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .filter { seen.insert(registrationNormalizeForSearch($0)).inserted }
+    }
+
+    func registrationSearchableBrandValues(for perfume: Perfume) -> [String] {
+        let values = [perfume.brand, PerfumePresentationSupport.displayBrand(perfume.brand)] + perfume.brandAliases
+        var seen = Set<String>()
+        return values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .filter { seen.insert(registrationNormalizeForSearch($0)).inserted }
+    }
+
+    func openPendingRegisterSuggestionIfPossible() {
+        guard mode == .register, let pendingRegisterSuggestion else { return }
+
+        guard let perfume = filteredPerfumeResults.first(where: {
+            registrationMatchesSuggestion($0, suggestion: pendingRegisterSuggestion)
+        }) else {
+            return
+        }
+
+        self.pendingRegisterSuggestion = nil
+        registerCollectedPerfume(perfume)
+    }
+
+    func registrationMatchesSuggestion(
+        _ perfume: Perfume,
+        suggestion: (name: String, brand: String)
+    ) -> Bool {
+        let targetNameValues = [suggestion.name, PerfumePresentationSupport.displayPerfumeName(suggestion.name)]
+            .map(registrationNormalizeForSearch(_:))
+            .filter { !$0.isEmpty }
+        let targetBrandValues = [suggestion.brand, PerfumePresentationSupport.displayBrand(suggestion.brand)]
+            .map(registrationNormalizeForSearch(_:))
+            .filter { !$0.isEmpty }
+
+        let perfumeNameValues = registrationSearchableNameValues(for: perfume)
+            .map(registrationNormalizeForSearch(_:))
+        let perfumeBrandValues = registrationSearchableBrandValues(for: perfume)
+            .map(registrationNormalizeForSearch(_:))
+
+        let hasMatchingName = targetNameValues.contains { perfumeNameValues.contains($0) }
+        let hasMatchingBrand = targetBrandValues.isEmpty
+            || targetBrandValues.contains { perfumeBrandValues.contains($0) }
+        return hasMatchingName && hasMatchingBrand
+    }
+
+    func registrationNormalizeForSearch(_ value: String) -> String {
+        value
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .joined()
     }
 
     func sectionCountText(title: String, count: Int) -> NSAttributedString {
@@ -1244,6 +1443,28 @@ private extension SearchViewController {
 
         let hasBrands = !brandResults.isEmpty
         let hasPerfumes = !filteredPerfumeResults.isEmpty
+
+        if mode == .register {
+            resultHeaderView.isHidden = true
+            brandSectionLabel.isHidden = true
+            brandTableView.isHidden = true
+            brandEmptyLabel.isHidden = true
+            perfumeCollectionView.isHidden = true
+            tableView.isHidden = !hasPerfumes
+            tableView.tableHeaderView = nil
+            tableView.tableFooterView = nil
+            tableView.reloadData()
+
+            if !hasPerfumes {
+                emptyView.configure(query: query)
+                emptyView.isHidden = false
+            } else {
+                emptyView.isHidden = true
+            }
+
+            applyKeyboardInset()
+            return
+        }
 
         resultHeaderView.isHidden = false
         brandSectionLabel.isHidden = false
@@ -1450,6 +1671,7 @@ private extension SearchViewController {
     }
 
     private func registerCollectedPerfume(_ perfume: Perfume) {
+        guard mode == .register else { return }
         guard !isRegisteringCollection else { return }
         let collectionID = perfume.collectionDocumentID
         if ownedPerfumeIDs.contains(collectionID) {
@@ -1457,23 +1679,57 @@ private extension SearchViewController {
             return
         }
 
+        presentCollectedPerfumeRegistration(for: perfume)
+    }
+
+    private func presentCollectedPerfumeRegistration(for perfume: Perfume) {
+        let registrationViewController = CollectedPerfumeRegistrationViewController(perfume: perfume)
+        registrationViewController.onRegister = { [weak self] info in
+            self?.saveCollectedPerfume(perfume, registrationInfo: info, sourceViewController: registrationViewController)
+        }
+        registrationViewController.onRetrySearch = { [weak self] in
+            self?.searchBar.becomeFirstResponder()
+        }
+        navigationController?.pushViewController(registrationViewController, animated: true)
+    }
+
+    private func saveCollectedPerfume(
+        _ perfume: Perfume,
+        registrationInfo: CollectedPerfumeRegistrationInfo,
+        sourceViewController: UIViewController
+    ) {
+        let collectionID = perfume.collectionDocumentID
         isRegisteringCollection = true
         view.isUserInteractionEnabled = false
+        sourceViewController.view.isUserInteractionEnabled = false
 
-        collectionRepository.saveCollectedPerfume(perfume, memo: nil)
+        collectionRepository.saveCollectedPerfume(perfume, registrationInfo: registrationInfo)
             .observe(on: MainScheduler.instance)
             .subscribe(onCompleted: { [weak self] in
                 guard let self else { return }
                 self.isRegisteringCollection = false
                 self.view.isUserInteractionEnabled = true
+                sourceViewController.view.isUserInteractionEnabled = true
                 self.ownedPerfumeIDs.insert(collectionID)
                 NotificationCenter.default.post(name: .perfumeCollectionDidChange, object: nil)
+                self.navigationController?.popToViewController(self, animated: false)
                 self.presentCollectionRegisteredAlert(for: perfume)
             }, onError: { [weak self] error in
                 guard let self else { return }
                 self.isRegisteringCollection = false
                 self.view.isUserInteractionEnabled = true
-                self.presentSaveFailure(error)
+                sourceViewController.view.isUserInteractionEnabled = true
+                if let limitError = error as? CollectionUsageLimitError {
+                    sourceViewController.showAppToast(message: limitError.localizedDescription)
+                } else {
+                    let alert = UIAlertController(
+                        title: nil,
+                        message: AppStrings.UIKitScreens.Search.registerFailed,
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(UIAlertAction(title: AppStrings.UIKitScreens.confirm, style: .default))
+                    sourceViewController.present(alert, animated: true)
+                }
             })
             .disposed(by: disposeBag)
     }
@@ -1501,7 +1757,10 @@ private extension SearchViewController {
     }
 
     private func presentTastingForm(for perfume: Perfume) {
-        let formView = TastingNoteSceneFactory.makeFormView(initialPerfume: perfume) { [weak self] perfumeName in
+        let formView = TastingNoteSceneFactory.makeFormView(
+            initialPerfume: perfume,
+            isOwnedPerfumeContext: ownedPerfumeIDs.contains(perfume.collectionDocumentID)
+        ) { [weak self] perfumeName in
             guard let self else { return }
             self.presentedTastingFormController?.dismiss(animated: true) {
                 self.presentedTastingFormController = nil
@@ -1574,7 +1833,7 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
             case .suggesting:
                 return suggestions.count
             case .result:
-                return 0
+                return mode == .register ? filteredPerfumeResults.count : 0
         }
     }
 
@@ -1633,6 +1892,15 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
             return cell
         }
 
+        if case .result = currentState, mode == .register {
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: PerfumeSearchResultCell.identifier,
+                for: indexPath
+            ) as! PerfumeSearchResultCell
+            cell.configure(with: filteredPerfumeResults[indexPath.row])
+            return cell
+        }
+
         return UITableViewCell()
     }
 
@@ -1652,6 +1920,7 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
 
             // 초기 상태 — 최근 검색어 탭 (자동저장 켜짐이고 검색어 있을 때만)
         if case .initial = currentState, isAutoSaveEnabled, !recentSearches.isEmpty {
+            guard mode != .register else { return }
             let query = recentSearches[indexPath.row].query
             searchBar.text = query
             searchTextRelay.accept(query)
@@ -1664,6 +1933,9 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
         if case .suggesting = currentState {
             let item = suggestions[indexPath.row]
             let query = item.displayName
+            if mode == .register, case let .perfume(name, brand, _) = item {
+                pendingRegisterSuggestion = (name: name, brand: brand)
+            }
             searchBar.text = query
             searchTextRelay.accept(query)
             updateSearchBarAccessory(for: query)
@@ -1671,10 +1943,19 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
             searchBar.resignFirstResponder()
             return
         }
+
+        if case .result = currentState, mode == .register {
+            registerCollectedPerfume(filteredPerfumeResults[indexPath.row])
+            return
+        }
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         guard tableView != brandTableView else { return 84 }
+
+        if case .result = currentState, mode == .register {
+            return 74
+        }
 
         if case .initial = currentState, !isAutoSaveEnabled || recentSearches.isEmpty {
             return 180
@@ -1866,6 +2147,90 @@ private final class BrandResultCell: UITableViewCell {
             $0.top.equalTo(brandNameLabel.snp.bottom).offset(8)
             $0.leading.trailing.equalTo(brandNameLabel)
             $0.bottom.lessThanOrEqualToSuperview().offset(-10)
+        }
+    }
+}
+
+private final class PerfumeSearchResultCell: UITableViewCell {
+    static let identifier = "PerfumeSearchResultCell"
+
+    private let thumbnailImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 12
+        $0.layer.cornerCurve = .continuous
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = UIColor(red: 0.93, green: 0.93, blue: 0.93, alpha: 1).cgColor
+        $0.backgroundColor = .systemGray6
+    }
+
+    private let nameLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16, weight: .medium)
+        $0.textColor = .label
+        $0.numberOfLines = 2
+        $0.lineBreakMode = .byWordWrapping
+    }
+
+    private let brandLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16, weight: .medium)
+        $0.textColor = .secondaryLabel
+        $0.numberOfLines = 1
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        thumbnailImageView.kf.cancelDownloadTask()
+        thumbnailImageView.image = nil
+        nameLabel.text = nil
+        brandLabel.text = nil
+    }
+
+    func configure(with perfume: Perfume) {
+        nameLabel.text = PerfumePresentationSupport.displayPerfumeName(perfume.name)
+        brandLabel.text = PerfumePresentationSupport.displayBrand(perfume.brand)
+
+        if let imageUrl = perfume.imageUrl, let url = URL(string: imageUrl) {
+            thumbnailImageView.kf.setImage(with: url)
+        }
+    }
+
+    private func setup() {
+        selectionStyle = .none
+        backgroundColor = .systemBackground
+        contentView.backgroundColor = .systemBackground
+
+        [thumbnailImageView, nameLabel, brandLabel].forEach {
+            contentView.addSubview($0)
+        }
+
+        thumbnailImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+            $0.top.greaterThanOrEqualToSuperview().offset(6)
+            $0.bottom.lessThanOrEqualToSuperview().offset(-6)
+            $0.size.equalTo(62)
+        }
+
+        nameLabel.snp.makeConstraints {
+            $0.leading.equalTo(thumbnailImageView.snp.trailing).offset(12)
+            $0.top.equalToSuperview().offset(6)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+
+        brandLabel.snp.makeConstraints {
+            $0.leading.equalTo(nameLabel)
+            $0.top.equalTo(nameLabel.snp.bottom).offset(2)
+            $0.trailing.lessThanOrEqualToSuperview().offset(-16)
+            $0.bottom.equalToSuperview().offset(-6)
         }
     }
 }

--- a/Sniff/Presentation/common/Tab/Search/ViewModels/SearchViewModel.swift
+++ b/Sniff/Presentation/common/Tab/Search/ViewModels/SearchViewModel.swift
@@ -241,8 +241,8 @@ final class SearchViewModel {
                 let lhsScore = brandMatchScore(for: $0, query: query)
                 let rhsScore = brandMatchScore(for: $1, query: query)
                 if lhsScore != rhsScore { return lhsScore > rhsScore }
-                let lhsPriority = PerfumeKoreanTranslator.domesticRetailPriority(for: $0)
-                let rhsPriority = PerfumeKoreanTranslator.domesticRetailPriority(for: $1)
+                let lhsPriority = PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: $0)
+                let rhsPriority = PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: $1)
                 if lhsPriority != rhsPriority { return lhsPriority > rhsPriority }
                 return $0.brand.localizedCaseInsensitiveCompare($1.brand) == .orderedAscending
             }
@@ -254,8 +254,8 @@ final class SearchViewModel {
             .filter { $0.score > 0 }
             .sorted { lhs, rhs in
                 if lhs.score != rhs.score { return lhs.score > rhs.score }
-                let lhsPriority = PerfumeKoreanTranslator.domesticRetailPriority(for: lhs.perfume)
-                let rhsPriority = PerfumeKoreanTranslator.domesticRetailPriority(for: rhs.perfume)
+                let lhsPriority = PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: lhs.perfume)
+                let rhsPriority = PerfumeKoreanTranslator.koreaBrandAvailabilityScore(for: rhs.perfume)
                 if lhsPriority != rhsPriority { return lhsPriority > rhsPriority }
                 if lhs.perfume.brand != rhs.perfume.brand {
                     return lhs.perfume.brand.localizedCaseInsensitiveCompare(rhs.perfume.brand) == .orderedAscending

--- a/Sniff/Presentation/common/Tab/TastingNote/Models/TastingNoteModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Models/TastingNoteModel.swift
@@ -12,6 +12,14 @@ import SwiftUI
 
 // MARK: - 시향 기록 모델
 
+enum TastingUsageContext: String, CaseIterable, Codable {
+    case today = "오늘 사용"
+    case recent = "최근 사용"
+    case memory = "기억으로 기록"
+
+    nonisolated var displayName: String { rawValue }
+}
+
 struct TastingNote: Identifiable, Codable {
     @DocumentID var id: String?
     var perfumeName: String
@@ -23,6 +31,7 @@ struct TastingNote: Identifiable, Codable {
     var revisitDesire: String?   // 다시 쓰고 싶은지 태그 (선택)
     var memo: String
     var perfumeImageURL: String?
+    var usageContext: String?
     var createdAt: Date
     var updatedAt: Date
 
@@ -38,6 +47,7 @@ struct TastingNote: Identifiable, Codable {
         case memo
         case perfumeImageURL
         case imageUrl
+        case usageContext
         case createdAt
         case updatedAt
     }
@@ -53,6 +63,7 @@ struct TastingNote: Identifiable, Codable {
         revisitDesire: String?,
         memo: String,
         perfumeImageURL: String?,
+        usageContext: String? = nil,
         createdAt: Date,
         updatedAt: Date
     ) {
@@ -66,6 +77,7 @@ struct TastingNote: Identifiable, Codable {
         self.revisitDesire = revisitDesire
         self.memo = memo
         self.perfumeImageURL = perfumeImageURL
+        self.usageContext = usageContext
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -84,6 +96,7 @@ struct TastingNote: Identifiable, Codable {
         perfumeImageURL =
             try container.decodeIfPresent(String.self, forKey: .perfumeImageURL)
             ?? container.decodeIfPresent(String.self, forKey: .imageUrl)
+        usageContext = try container.decodeIfPresent(String.self, forKey: .usageContext)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
@@ -101,6 +114,7 @@ struct TastingNote: Identifiable, Codable {
         try container.encodeIfPresent(revisitDesire, forKey: .revisitDesire)
         try container.encode(memo, forKey: .memo)
         try container.encodeIfPresent(perfumeImageURL, forKey: .perfumeImageURL)
+        try container.encodeIfPresent(usageContext, forKey: .usageContext)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
     }
@@ -137,28 +151,9 @@ struct FragellaFragrance: Identifiable {
     }
 }
 
-// MARK: - 분위기&이미지 태그 목록 (18개)
+// MARK: - 분위기&이미지 태그 목록
 
-let kMoodTagList: [String] = [
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[0],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[1],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[2],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[3],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[4],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[5],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[6],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[7],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[8],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[9],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[10],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[11],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[12],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[13],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[14],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[15],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[16],
-    AppStrings.DomainDisplay.TastingNoteData.moodTagList[17]
-]
+let kMoodTagList: [String] = AppStrings.DomainDisplay.TastingNoteData.moodTagList
 
 // MARK: - 향 계열(Accord) 색상
 
@@ -174,23 +169,23 @@ extension String {
 // MARK: - 이전 무드 태그 → 현재 무드 태그 매핑
 
 let kLegacyMoodTagToKorean: [String: String] = [
-    "Woody": "묵직한",
+    "Woody": "짙은",
     "Fresh": "상큼한",
     "Amber(Oriental)": "따뜻한",
-    "Musky": "보송보송한",
+    "Musky": "부드러운",
     "White Floral": "은은한",
     "Rose": "은은한",
-    "Powdery": "보송보송한",
+    "Powdery": "부드러운",
     "Vanilla": "달콤한",
     "Sweet": "달콤한",
-    "Spicy": "강렬한",
+    "Spicy": "짙은",
     "Citrus": "상큼한",
     "Green": "자연스러운",
     "Aquatic": "시원한",
     "Water": "시원한",
-    "Leather": "묵직한",
-    "Oud": "묵직한",
-    "우디": "묵직한",
+    "Leather": "짙은",
+    "Oud": "짙은",
+    "우디": "짙은",
     "앰버(오리엔탈)": "따뜻한",
     "바닐라": "달콤한",
     "시트러스": "상큼한",
@@ -198,6 +193,15 @@ let kLegacyMoodTagToKorean: [String: String] = [
     "아쿠아틱": "시원한",
     "워터": "시원한",
     "워터리": "시원한",
+    "강렬한": "짙은",
+    "보송보송한": "부드러운",
+    "묵직한": "짙은",
+    "가벼운": "맑은",
+    "포근한": "따뜻한",
+    "고급스러운": "세련된",
+    "중성적인": "시크한",
+    "싱그러운": "자연스러운",
+    "무거운": "짙은",
 ]
 
 // MARK: - 별점 라벨

--- a/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/ViewModels/TastingNoteFormViewModel.swift
@@ -11,6 +11,31 @@ import FirebaseAuth
 import Combine
 import FirebaseFirestore
 
+struct TastingPerfumeMatchCandidate: Identifiable, Equatable {
+    let brandName: String
+    let perfumeName: String?
+    let imageURL: String?
+
+    var id: String {
+        "\(brandName.lowercased())|\((perfumeName ?? "").lowercased())"
+    }
+
+    var title: String {
+        if let perfumeName, !perfumeName.isEmpty {
+            return PerfumePresentationSupport.displayPerfumeName(perfumeName)
+        }
+        return PerfumePresentationSupport.displayBrand(brandName)
+    }
+
+    var subtitle: String {
+        if perfumeName == nil {
+            let displayBrand = PerfumePresentationSupport.displayBrand(brandName)
+            return displayBrand == brandName ? "브랜드 후보" : "\(brandName) 브랜드 후보"
+        }
+        return PerfumePresentationSupport.displayBrand(brandName)
+    }
+}
+
 @MainActor
 final class TastingNoteFormViewModel: ObservableObject {
 
@@ -26,6 +51,7 @@ final class TastingNoteFormViewModel: ObservableObject {
     @Published var rating: Int = 0
     @Published var selectedMoodTags: Set<String> = []
     @Published var revisitDesire: String? = nil   // 다시 쓰고 싶은지 (단일 선택, 선택 안 해도 저장 가능)
+    @Published var usageContext: String? = nil
     @Published var memo: String = ""
 
     // MARK: - Published (상태)
@@ -33,16 +59,21 @@ final class TastingNoteFormViewModel: ObservableObject {
     @Published private(set) var isSaving: Bool = false
     @Published private(set) var saveSuccess: Bool = false
     @Published private(set) var savedPerfumeName: String = ""
+    @Published private(set) var perfumeMatchCandidates: [TastingPerfumeMatchCandidate] = []
     @Published var errorMessage: String?
 
     // MARK: - Public
 
     var allMoodTags: [String] { kMoodTagList }
+    var allUsageContexts: [String] { TastingUsageContext.allCases.map(\.displayName) }
 
     private var editingNote: TastingNote?
     private let localRepository: LocalTastingNoteRepository
+    private let localPerfumeSearchService: LocalPerfumeSearchService
+    private let isOwnedPerfumeContext: Bool
     var isEditMode: Bool { editingNote != nil }
     var navigationTitle: String { isEditMode ? AppStrings.TastingNoteUI.List.edit : AppStrings.TastingNoteUI.List.add }
+    var shouldShowUsageContext: Bool { isOwnedPerfumeContext || usageContext != nil }
 
     var canSave: Bool {
         isPerfumeNameValid &&
@@ -120,18 +151,32 @@ final class TastingNoteFormViewModel: ObservableObject {
     private static let maxMemoCount = 2000
     private static let allowedWhitespaceScalars = CharacterSet.whitespacesAndNewlines
     private static let allowedPunctuationScalars = CharacterSet(charactersIn: ".,!?~")
+    private static let manualBrandCorrections: [String: String] = [
+        "조말롱": "Jo Malone London",
+        "조말론": "Jo Malone London",
+        "딥티그": "Diptyque",
+        "딥티크": "Diptyque",
+        "그리드": "Creed",
+        "크리드": "Creed"
+    ]
 
     private var perfumeImageURL: String?
+    private var isApplyingMatchCandidate = false
 
     // MARK: - Init
 
     init(
         localRepository: LocalTastingNoteRepository,
+        localPerfumeSearchService: LocalPerfumeSearchService = LocalPerfumeSearchService(),
         editingNote: TastingNote? = nil,
-        initialPerfume: Perfume? = nil
+        initialPerfume: Perfume? = nil,
+        isOwnedPerfumeContext: Bool = false
     ) {
         self.localRepository = localRepository
+        self.localPerfumeSearchService = localPerfumeSearchService
         self.editingNote = editingNote
+        self.isOwnedPerfumeContext = isOwnedPerfumeContext
+        self.localPerfumeSearchService.buildIndex(includesUserData: false)
         if let editingNote {
             loadEditingNote(editingNote)
         } else if let initialPerfume {
@@ -152,6 +197,7 @@ final class TastingNoteFormViewModel: ObservableObject {
             kLegacyMoodTagToKorean[$0] ?? $0
         })
         revisitDesire = note.revisitDesire
+        usageContext = note.usageContext
         memo = note.memo
         perfumeImageURL = note.perfumeImageURL
     }
@@ -179,6 +225,55 @@ final class TastingNoteFormViewModel: ObservableObject {
         revisitDesire = (revisitDesire == tag) ? nil : tag
     }
 
+    func toggleUsageContext(_ context: String) {
+        usageContext = (usageContext == context) ? nil : context
+    }
+
+    func refreshPerfumeMatchCandidates() {
+        guard !isApplyingMatchCandidate else { return }
+
+        let perfumeQuery = perfumeName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let brandQuery = brandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !perfumeQuery.isEmpty || !brandQuery.isEmpty else {
+            perfumeMatchCandidates = []
+            return
+        }
+
+        var candidates: [TastingPerfumeMatchCandidate] = []
+        let queries = [
+            [brandQuery, perfumeQuery].filter { !$0.isEmpty }.joined(separator: " "),
+            perfumeQuery,
+            brandQuery
+        ]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count >= 2 }
+
+        for query in queries {
+            let suggestions = localPerfumeSearchService.suggestions(for: query)
+            candidates.append(contentsOf: suggestions.compactMap(makeCandidate(from:)))
+        }
+        candidates.append(contentsOf: brandCorrectionCandidates(for: brandQuery))
+        if perfumeQuery.count >= 2, brandQuery.isEmpty {
+            candidates.append(contentsOf: brandCorrectionCandidates(for: perfumeQuery))
+        }
+
+        perfumeMatchCandidates = uniqueCandidates(candidates)
+            .filter { !isSameCurrentInput($0) }
+            .prefix(3)
+            .map { $0 }
+    }
+
+    func applyMatchCandidate(_ candidate: TastingPerfumeMatchCandidate) {
+        isApplyingMatchCandidate = true
+        brandName = PerfumePresentationSupport.displayBrand(candidate.brandName)
+        if let perfumeName = candidate.perfumeName {
+            self.perfumeName = PerfumePresentationSupport.displayPerfumeName(perfumeName)
+        }
+        perfumeImageURL = candidate.imageURL
+        perfumeMatchCandidates = []
+        isApplyingMatchCandidate = false
+    }
+
     // MARK: - 초기화
 
     func reset() {
@@ -193,9 +288,11 @@ final class TastingNoteFormViewModel: ObservableObject {
             mainAccords = []
             concentration = ""
             perfumeImageURL = nil
+            perfumeMatchCandidates = []
             rating = 0
             selectedMoodTags = []
             revisitDesire = nil
+            usageContext = nil
             memo = ""
         }
     }
@@ -223,6 +320,7 @@ final class TastingNoteFormViewModel: ObservableObject {
             revisitDesire: revisitDesire,
             memo: memo.trimmingCharacters(in: .whitespacesAndNewlines),
             perfumeImageURL: perfumeImageURL,
+            usageContext: shouldShowUsageContext ? usageContext : nil,
             createdAt: editingNote?.createdAt ?? now,
             updatedAt: now
         )
@@ -243,6 +341,113 @@ final class TastingNoteFormViewModel: ObservableObject {
             let ri = allMoodTags.firstIndex(of: $1) ?? Int.max
             return li < ri
         }
+    }
+
+    private func makeCandidate(from suggestion: SuggestionItem) -> TastingPerfumeMatchCandidate? {
+        switch suggestion {
+        case let .brand(name, imageUrl):
+            return TastingPerfumeMatchCandidate(
+                brandName: name,
+                perfumeName: nil,
+                imageURL: imageUrl
+            )
+        case let .perfume(name, brand, imageUrl):
+            return TastingPerfumeMatchCandidate(
+                brandName: brand,
+                perfumeName: name,
+                imageURL: imageUrl
+            )
+        }
+    }
+
+    private func brandCorrectionCandidates(for query: String) -> [TastingPerfumeMatchCandidate] {
+        let normalizedQuery = normalizeForCandidateMatch(query)
+        guard normalizedQuery.count >= 2 else { return [] }
+
+        var candidates: [TastingPerfumeMatchCandidate] = []
+        if let corrected = Self.manualBrandCorrections[normalizedQuery] {
+            candidates.append(TastingPerfumeMatchCandidate(brandName: corrected, perfumeName: nil, imageURL: nil))
+        }
+
+        let dictionaryCandidates = PerfumeKoreanTranslator.koreanToBrand.map { pair in
+            (korean: pair.key, english: pair.value, score: brandCandidateScore(query: normalizedQuery, candidate: pair.key))
+        }
+            .filter { $0.score > 0 }
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                return lhs.korean.localizedCaseInsensitiveCompare(rhs.korean) == .orderedAscending
+            }
+            .prefix(2)
+            .map { TastingPerfumeMatchCandidate(brandName: $0.english, perfumeName: nil, imageURL: nil) }
+
+        candidates.append(contentsOf: dictionaryCandidates)
+        return candidates
+    }
+
+    private func brandCandidateScore(query: String, candidate: String) -> Int {
+        let normalizedCandidate = normalizeForCandidateMatch(candidate)
+        if normalizedCandidate == query { return 1_000 }
+        if normalizedCandidate.contains(query) || query.contains(normalizedCandidate) { return 800 }
+        if isNearTypo(normalizedCandidate, query) { return 650 }
+        return 0
+    }
+
+    private func uniqueCandidates(_ candidates: [TastingPerfumeMatchCandidate]) -> [TastingPerfumeMatchCandidate] {
+        var seen = Set<String>()
+        return candidates.filter { seen.insert($0.id).inserted }
+    }
+
+    private func isSameCurrentInput(_ candidate: TastingPerfumeMatchCandidate) -> Bool {
+        let currentBrand = normalizeForCandidateMatch(brandName)
+        let candidateBrand = normalizeForCandidateMatch(PerfumePresentationSupport.displayBrand(candidate.brandName))
+        let currentPerfume = normalizeForCandidateMatch(perfumeName)
+        let candidatePerfume = normalizeForCandidateMatch(
+            candidate.perfumeName.map(PerfumePresentationSupport.displayPerfumeName) ?? ""
+        )
+
+        if candidate.perfumeName == nil {
+            return !currentBrand.isEmpty && currentBrand == candidateBrand
+        }
+        return !currentBrand.isEmpty
+            && !currentPerfume.isEmpty
+            && currentBrand == candidateBrand
+            && currentPerfume == candidatePerfume
+    }
+
+    private func normalizeForCandidateMatch(_ value: String) -> String {
+        value
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .joined()
+    }
+
+    private func isNearTypo(_ lhs: String, _ rhs: String) -> Bool {
+        guard lhs.count >= 2, rhs.count >= 2 else { return false }
+        guard abs(lhs.count - rhs.count) <= 1 else { return false }
+        return editDistance(lhs, rhs, maxDistance: 1) <= 1
+    }
+
+    private func editDistance(_ lhs: String, _ rhs: String, maxDistance: Int) -> Int {
+        let lhs = Array(lhs)
+        let rhs = Array(rhs)
+        if abs(lhs.count - rhs.count) > maxDistance { return maxDistance + 1 }
+        if lhs.isEmpty { return rhs.count }
+        if rhs.isEmpty { return lhs.count }
+
+        var previous = Array(0...rhs.count)
+        for i in 1...lhs.count {
+            var current = [i] + Array(repeating: 0, count: rhs.count)
+            var rowMinimum = current[0]
+            for j in 1...rhs.count {
+                let cost = lhs[i - 1] == rhs[j - 1] ? 0 : 1
+                current[j] = min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + cost)
+                rowMinimum = min(rowMinimum, current[j])
+            }
+            if rowMinimum > maxDistance { return maxDistance + 1 }
+            previous = current
+        }
+        return previous[rhs.count]
     }
 
     private static func isKoreanScalar(_ scalar: UnicodeScalar) -> Bool {

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteDetailView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteDetailView.swift
@@ -55,6 +55,13 @@ struct TastingNoteDetailView: View {
                         .padding(.top, 40)
                         .padding(.bottom, 0)
 
+                    if let usageContext = currentNote.usageContext, !usageContext.isEmpty {
+                        usageContextSection(usageContext)
+                            .padding(.horizontal, 16)
+                            .padding(.top, 40)
+                            .padding(.bottom, 0)
+                    }
+
                     // 시향 메모 섹션 (구분선 없음, 40pt 상단 여백)
                     memoSection
                         .padding(.horizontal, 16)
@@ -235,7 +242,7 @@ struct TastingNoteDetailView: View {
 
             // 아웃라인 스타일 칩 (와이어프레임: 검정 테두리, 흰 배경, 검정 텍스트)
             ChipFlowLayout(spacing: 8) {
-                ForEach(currentNote.moodTags, id: \.self) { tag in
+                ForEach(displayMoodTags, id: \.self) { tag in
                     Text(tag)
                         .font(.custom("Pretendard", size: 13).weight(.regular))
                         .foregroundColor(Color(.label))
@@ -248,6 +255,32 @@ struct TastingNoteDetailView: View {
                         )
                 }
             }
+        }
+    }
+
+    private var displayMoodTags: [String] {
+        var seen = Set<String>()
+        return currentNote.moodTags
+            .map { kLegacyMoodTagToKorean[$0] ?? $0 }
+            .filter { seen.insert($0).inserted }
+    }
+
+    private func usageContextSection(_ usageContext: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("사용 맥락")
+                .font(.custom("Pretendard", size: 17).weight(.semibold))
+                .foregroundColor(.primary)
+
+            Text(usageContext)
+                .font(.custom("Pretendard", size: 13).weight(.regular))
+                .foregroundColor(Color(.label))
+                .padding(.horizontal, 13)
+                .padding(.vertical, 7)
+                .background(Color(.systemBackground))
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule().stroke(Color(.label), lineWidth: 1)
+                )
         }
     }
 

--- a/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteFormView.swift
+++ b/Sniff/Presentation/common/Tab/TastingNote/Views/TastingNoteFormView.swift
@@ -7,6 +7,7 @@
 
 // MARK: - 등록 / 수정 화면
 import SwiftUI
+import Kingfisher
 
 struct TastingNoteFormView: View {
 
@@ -45,6 +46,13 @@ struct TastingNoteFormView: View {
                         .padding(.top, 24)
                         .padding(.bottom, 0)
 
+                    if vm.shouldShowUsageContext {
+                        usageContextSection
+                            .padding(.horizontal, 20)
+                            .padding(.top, 36)
+                            .padding(.bottom, 0)
+                    }
+
                     memoSection
                         .padding(.horizontal, 20)
                         .padding(.top, 42)
@@ -61,6 +69,12 @@ struct TastingNoteFormView: View {
         .toolbar(.hidden, for: .navigationBar)
         .onChange(of: vm.saveSuccess) { success in
             if success { onSaveSuccess(vm.savedPerfumeName); dismiss() }
+        }
+        .onChange(of: vm.perfumeName) { _ in
+            vm.refreshPerfumeMatchCandidates()
+        }
+        .onChange(of: vm.brandName) { _ in
+            vm.refreshPerfumeMatchCandidates()
         }
         .alert(AppStrings.TastingNoteFormUI.errorTitle, isPresented: Binding(
             get: { vm.errorMessage != nil },
@@ -117,6 +131,54 @@ struct TastingNoteFormView: View {
                 text: $vm.brandName
             )
             .padding(.top, 24)
+
+            if !vm.perfumeMatchCandidates.isEmpty {
+                perfumeMatchCandidateSection
+                    .padding(.top, 14)
+            }
+        }
+    }
+
+    private var perfumeMatchCandidateSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("혹시 이 향수인가요?")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.secondary)
+
+            VStack(spacing: 8) {
+                ForEach(vm.perfumeMatchCandidates) { candidate in
+                    Button {
+                        vm.applyMatchCandidate(candidate)
+                    } label: {
+                        HStack(spacing: 12) {
+                            PerfumeMatchCandidateThumbnail(imageURL: candidate.imageURL)
+
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(candidate.title)
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundColor(.primary)
+                                    .lineLimit(1)
+
+                                Text(candidate.subtitle)
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(1)
+                            }
+
+                            Spacer()
+
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(Color(.systemGray3))
+                        }
+                        .padding(.horizontal, 12)
+                        .frame(height: 58)
+                        .background(Color(.systemGray6))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
         }
     }
 
@@ -269,6 +331,26 @@ struct TastingNoteFormView: View {
         }
     }
 
+    private var usageContextSection: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            Text("사용 맥락")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(.primary)
+
+            HStack(spacing: 7) {
+                ForEach(vm.allUsageContexts, id: \.self) { context in
+                    MoodChip(
+                        title: context,
+                        isSelected: vm.usageContext == context
+                    ) {
+                        vm.toggleUsageContext(context)
+                    }
+                }
+                Spacer()
+            }
+        }
+    }
+
     // MARK: - 시향 메모 섹션
 
     private var memoSection: some View {
@@ -366,6 +448,33 @@ struct TastingNoteFormView: View {
                         .frame(height: 0.5)
                 }
                 .ignoresSafeArea(edges: .bottom)
+        )
+    }
+}
+
+private struct PerfumeMatchCandidateThumbnail: View {
+    let imageURL: String?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.systemBackground))
+
+            if let imageURL, let url = URL(string: imageURL) {
+                KFImage(url)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(5)
+            } else {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(Color(.systemGray3))
+            }
+        }
+        .frame(width: 42, height: 42)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.systemGray5), lineWidth: 1)
         )
     }
 }

--- a/Sniff/Sniff.xcdatamodeld/Sniff.xcdatamodel/contents
+++ b/Sniff/Sniff.xcdatamodeld/Sniff.xcdatamodel/contents
@@ -16,6 +16,7 @@
         <attribute name="revisitDesire" optional="YES" attributeType="String"/>
         <attribute name="syncStatus" optional="NO" attributeType="String" defaultValueString="pending"/>
         <attribute name="updatedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="usageContext" optional="YES" attributeType="String"/>
     </entity>
     <elements>
         <element name="LocalTastingNoteEntity" positionX="-63" positionY="-18" width="128" height="254"/>


### PR DESCRIPTION
- 시향기 입력 중 향수명/브랜드명 오타 후보를 로컬에서 제안
- 네트워크 호출 없이 로컬 캐시와 브랜드 사전을 사용하도록 처리
- 사용자가 후보를 눌러 보정한 뒤 저장할 수 있게 구성
- 조말롱, 딥티그, 그리드 같은 흔한 입력 보정 추가